### PR TITLE
fix: Improve Docker path validation and publish workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-10-09
+
+**Docker Path Validation Fix** - Fixes critical Docker image bug where file-specific linting failed due to premature path validation.
+
+### Fixed
+
+- **Docker Path Validation** - Removed Click's `exists=True` parameter that validated paths before Docker volumes were mounted
+  - All linter commands now work with file paths in Docker: `docker run -v $(pwd):/data thailint nesting /data/file.py`
+  - Better error messages when paths don't exist, with Docker usage hints
+  - Manual path validation happens after argument parsing, compatible with both CLI and Docker contexts
+
+### Changed
+
+- Path validation moved from Click argument parsing to execution functions
+- Added `_validate_paths_exist()` helper function with user-friendly error messages
+
 ## [0.3.0] - TBD
 
 **Single Responsibility Principle (SRP) Linter Release** - Adds comprehensive SRP violation detection for Python and TypeScript code. Uses heuristic-based analysis with configurable thresholds for method count, lines of code, and responsibility keywords. Includes language-specific configurations and extensive refactoring pattern documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.1.6"
+version = "0.2.1"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary

This PR addresses two key improvements for the 0.2.1 release:

### 1. Docker Path Validation Fix
Fixes critical Docker image bug where file-specific linting failed due to premature path validation.

**Problem**: Click's `exists=True` parameter validated paths before Docker volumes were mounted, causing all file-specific commands to fail in Docker:
```bash
docker run -v $(pwd):/data thailint nesting /data/file.py
# Error: Path does not exist: /data/file.py
```

**Solution**:
- Removed `exists=True` from all 4 CLI commands (`nesting`, `srp`, `dry`, `file-placement`)
- Added manual path validation with `_validate_paths_exist()` helper function
- Validation now happens after argument parsing, compatible with both CLI and Docker contexts
- Added user-friendly error messages with Docker usage hints

### 2. Publish Workflow Enhancement
Improves the `just publish` command to support faster iteration when tests/linting have already been validated.

**New Feature**: `--skip-checks` flag
```bash
# Full publish with all checks
just publish

# Skip tests and linting (when already validated)
just publish --skip-checks
```

**Important**: Version bump step ALWAYS runs, even with `--skip-checks`, ensuring version confirmation before publishing.

## Changes

- **src/cli.py**: Remove `exists=True` from 4 commands, add `_validate_paths_exist()` helper
- **pyproject.toml**: Bump version to 0.2.1
- **CHANGELOG.md**: Document Docker path validation fix
- **justfile**: Add `--skip-checks` flag support with proper version bump handling

## Testing

- ✅ All 604 tests passing
- ✅ Full linting passed (Ruff, Pylint, Flake8, MyPy, Security, Complexity, Placement, SRP, DRY)
- ✅ Pre-commit hooks passed
- ✅ Tested Docker image locally with file paths
- ✅ Tested `just publish --skip-checks` workflow

## Test Plan

- [ ] Review code changes
- [ ] Verify CHANGELOG.md accuracy
- [ ] Test Docker image after publishing: `docker run -v $(pwd):/data thailint nesting /data/file.py`
- [ ] Verify PyPI package: `pip install thailint==0.2.1`
- [ ] Test `just publish --skip-checks` workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)