### PR TITLE
perf: Optimize DRY linter with line-to-node index for 17x speedup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.4.3"
+version = "0.4.4"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Implement line-to-node index to eliminate repeated AST walking bottleneck in Python DRY linter. This optimization reduces node operations by 99.75% and delivers dramatic performance improvements across single files and directory scans.

## Performance Improvements

- **Single file** (1,555 lines): 6.8s → 0.40s (17x faster)
- **Directory scan** (77 files): >120s timeout → 0.89s (>135x faster)  
- **AST operations**: 3.46M nodes → 8,509 nodes (99.75% reduction)

## Implementation Details

### Line-to-Node Index
- Maps each line number to overlapping AST nodes
- Built once during `analyze()` after parsing AST
- Enables O(1) lookups instead of O(n) `ast.walk()` calls

### Key Changes
- `_build_line_to_node_index()`: Build index mapping line numbers to AST nodes
- `_check_overlapping_nodes()`: Use cached index for O(1) lookups
- `_check_nodes_via_index()`: Fast path using line-to-node index
- `_check_nodes_via_walk()`: Fallback for standalone calls (backward compatibility)
- Proper cache cleanup in `finally` block to prevent memory leaks

### Code Quality
- Refactored complex methods to maintain A-grade Xenon complexity
- Extracted helper methods to reduce nesting depth
- Added pylint suppressions for justified multi-argument methods
- All 62 DRY linter tests pass

## Additional Optimizations

- **Lazy rule discovery** in orchestrator to eliminate initialization overhead
- **AST caching** to avoid re-parsing for each hash window check

## Testing

✅ All tests pass (62/62 DRY tests)  
✅ All linters pass (MyPy, Pylint 10/10, Ruff, Flake8, Xenon A-grade, nesting depth)

## Test Plan

- [x] Run DRY linter tests: `pytest tests/unit/linters/dry/ -v`
- [x] Verify performance improvement with `time python -m src.cli dry src/cli.py`
- [x] Run full linting suite: `just lint-all`
- [x] Confirm all type checks pass with MyPy
- [x] Verify Xenon complexity is A-grade
- [x] Test directory scan performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)