### PR TITLE
docs: Set up ReadTheDocs documentation hosting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration file for thai-lint
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation with MkDocs
+mkdocs:
+  configuration: mkdocs.yml
+
+# Python dependencies required to build documentation
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-296%2F296%20passing-brightgreen.svg)](tests/)
 [![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen.svg)](htmlcov/)
+[![Documentation Status](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/en/latest/?badge=latest)
 
 The AI Linter - Enterprise-ready linting and governance for AI-generated code across multiple languages.
 
 ## Documentation
 
 **New to thailint?** Start here:
-- **[Quick Start Guide](docs/quick-start.md)** - Get running in 5 minutes
-- **[Configuration Reference](docs/configuration.md)** - Complete config options for all linters
-- **[Troubleshooting Guide](docs/troubleshooting.md)** - Common issues and solutions
+- **[Quick Start Guide](https://thai-lint.readthedocs.io/en/latest/quick-start/)** - Get running in 5 minutes
+- **[Configuration Reference](https://thai-lint.readthedocs.io/en/latest/configuration/)** - Complete config options for all linters
+- **[Troubleshooting Guide](https://thai-lint.readthedocs.io/en/latest/troubleshooting/)** - Common issues and solutions
 
-**Full Documentation:** Browse the **[docs/](docs/)** folder for comprehensive guides covering installation, all linters, configuration patterns, and integration examples.
+**Full Documentation:** Browse the **[documentation site](https://thai-lint.readthedocs.io/)** for comprehensive guides covering installation, all linters, configuration patterns, and integration examples.
 
 ## Overview
 
@@ -31,7 +32,7 @@ We're not trying to replace the wonderful existing linters like Pylint, ESLint, 
 
 thailint complements your existing linting stack by catching the patterns AI tools repeatedly miss.
 
-**Complete documentation available in the [docs/](docs/) folder** covering installation, configuration, all linters, and troubleshooting.
+**Complete documentation available at [thai-lint.readthedocs.io](https://thai-lint.readthedocs.io/)** covering installation, configuration, all linters, and troubleshooting.
 
 ## Features
 
@@ -129,7 +130,7 @@ thailint dry --config .thailint.yaml src/
 thailint dry --format json src/
 ```
 
-**New to thailint?** See the **[Quick Start Guide](docs/quick-start.md)** for a complete walkthrough including config generation, understanding output, and next steps.
+**New to thailint?** See the **[Quick Start Guide](https://thai-lint.readthedocs.io/en/latest/quick-start/)** for a complete walkthrough including config generation, understanding output, and next steps.
 
 ### Library Mode
 
@@ -321,9 +322,9 @@ magic-numbers:
 }
 ```
 
-See [Configuration Guide](docs/configuration.md) for complete reference.
+See [Configuration Guide](https://thai-lint.readthedocs.io/en/latest/configuration/) for complete reference.
 
-**Need help with ignores?** See **[How to Ignore Violations](docs/how-to-ignore-violations.md)** for complete guide to all ignore levels (line, method, class, file, repository).
+**Need help with ignores?** See **[How to Ignore Violations](https://thai-lint.readthedocs.io/en/latest/how-to-ignore-violations/)** for complete guide to all ignore levels (line, method, class, file, repository).
 
 ## Nesting Depth Linter
 
@@ -409,7 +410,7 @@ Common patterns to reduce nesting:
 - **TypeScript**: Full support (if/for/while/try/switch)
 - **JavaScript**: Supported via TypeScript parser
 
-See [Nesting Linter Guide](docs/nesting-linter.md) for comprehensive documentation and refactoring patterns.
+See [Nesting Linter Guide](https://thai-lint.readthedocs.io/en/latest/nesting-linter/) for comprehensive documentation and refactoring patterns.
 
 ## Single Responsibility Principle (SRP) Linter
 
@@ -526,7 +527,7 @@ Common patterns to fix SRP violations (discovered during dogfooding):
 - **After**: Extract Class pattern applied - 5 focused classes (ConfigLoader, PatternValidator, RuleChecker, PathResolver, FilePlacementLinter)
 - **Result**: Each class ≤8 methods, ≤150 LOC, single responsibility
 
-See [SRP Linter Guide](docs/srp-linter.md) for comprehensive documentation and refactoring patterns.
+See [SRP Linter Guide](https://thai-lint.readthedocs.io/en/latest/srp-linter/) for comprehensive documentation and refactoring patterns.
 
 ## DRY Linter (Don't Repeat Yourself)
 
@@ -679,7 +680,7 @@ Built-in filters automatically exclude common non-duplication patterns:
 3. **Extract Utility Module**: Move helper functions to shared utilities
 4. **Template Method**: Use function parameters for variations
 
-See [DRY Linter Guide](docs/dry-linter.md) for comprehensive documentation, storage modes, and refactoring patterns.
+See [DRY Linter Guide](https://thai-lint.readthedocs.io/en/latest/dry-linter/) for comprehensive documentation, storage modes, and refactoring patterns.
 
 ## Magic Numbers Linter
 
@@ -831,7 +832,7 @@ def get_ports():  # thailint: ignore[magic-numbers] - Standard ports
 # thailint: ignore-file[magic-numbers]
 ```
 
-See **[How to Ignore Violations](docs/how-to-ignore-violations.md)** and **[Magic Numbers Linter Guide](docs/magic-numbers-linter.md)** for complete documentation.
+See **[How to Ignore Violations](https://thai-lint.readthedocs.io/en/latest/how-to-ignore-violations/)** and **[Magic Numbers Linter Guide](https://thai-lint.readthedocs.io/en/latest/magic-numbers-linter/)** for complete documentation.
 
 ## Pre-commit Hooks
 
@@ -893,7 +894,7 @@ repos:
         pass_filenames: true
 ```
 
-See **[Pre-commit Hooks Guide](docs/pre-commit-hooks.md)** for complete documentation, troubleshooting, and advanced configuration.
+See **[Pre-commit Hooks Guide](https://thai-lint.readthedocs.io/en/latest/pre-commit-hooks/)** for complete documentation, troubleshooting, and advanced configuration.
 
 ## Common Use Cases
 
@@ -1110,20 +1111,20 @@ docker run --rm -v /path/to/workspace:/workspace \
 
 ### Comprehensive Guides
 
-- **[Getting Started](docs/getting-started.md)** - Installation, first lint, basic config
-- **[Configuration Reference](docs/configuration.md)** - Complete config options (YAML/JSON)
-- **[How to Ignore Violations](docs/how-to-ignore-violations.md)** - Complete guide to all ignore levels
-- **[API Reference](docs/api-reference.md)** - Library API documentation
-- **[CLI Reference](docs/cli-reference.md)** - All CLI commands and options
-- **[Deployment Modes](docs/deployment-modes.md)** - CLI, Library, and Docker usage
-- **[File Placement Linter](docs/file-placement-linter.md)** - Detailed linter guide
-- **[Magic Numbers Linter](docs/magic-numbers-linter.md)** - Magic numbers detection guide
-- **[Nesting Depth Linter](docs/nesting-linter.md)** - Nesting depth analysis guide
-- **[SRP Linter](docs/srp-linter.md)** - Single Responsibility Principle guide
-- **[DRY Linter](docs/dry-linter.md)** - Duplicate code detection guide
-- **[Pre-commit Hooks](docs/pre-commit-hooks.md)** - Automated quality checks
-- **[Publishing Guide](docs/releasing.md)** - Release and publishing workflow
-- **[Publishing Checklist](docs/publishing-checklist.md)** - Post-publication validation
+- **[Getting Started](https://thai-lint.readthedocs.io/en/latest/getting-started/)** - Installation, first lint, basic config
+- **[Configuration Reference](https://thai-lint.readthedocs.io/en/latest/configuration/)** - Complete config options (YAML/JSON)
+- **[How to Ignore Violations](https://thai-lint.readthedocs.io/en/latest/how-to-ignore-violations/)** - Complete guide to all ignore levels
+- **[API Reference](https://thai-lint.readthedocs.io/en/latest/api-reference/)** - Library API documentation
+- **[CLI Reference](https://thai-lint.readthedocs.io/en/latest/cli-reference/)** - All CLI commands and options
+- **[Deployment Modes](https://thai-lint.readthedocs.io/en/latest/deployment-modes/)** - CLI, Library, and Docker usage
+- **[File Placement Linter](https://thai-lint.readthedocs.io/en/latest/file-placement-linter/)** - Detailed linter guide
+- **[Magic Numbers Linter](https://thai-lint.readthedocs.io/en/latest/magic-numbers-linter/)** - Magic numbers detection guide
+- **[Nesting Depth Linter](https://thai-lint.readthedocs.io/en/latest/nesting-linter/)** - Nesting depth analysis guide
+- **[SRP Linter](https://thai-lint.readthedocs.io/en/latest/srp-linter/)** - Single Responsibility Principle guide
+- **[DRY Linter](https://thai-lint.readthedocs.io/en/latest/dry-linter/)** - Duplicate code detection guide
+- **[Pre-commit Hooks](https://thai-lint.readthedocs.io/en/latest/pre-commit-hooks/)** - Automated quality checks
+- **[Publishing Guide](https://thai-lint.readthedocs.io/en/latest/releasing/)** - Release and publishing workflow
+- **[Publishing Checklist](https://thai-lint.readthedocs.io/en/latest/publishing-checklist/)** - Post-publication validation
 
 ### Examples
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,167 @@
+# thai-lint
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Tests](https://img.shields.io/badge/tests-296%2F296%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/tree/main/tests)
+[![Coverage](https://img.shields.io/badge/coverage-87%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
+[![Documentation Status](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/en/latest/?badge=latest)
+
+The AI Linter - Enterprise-ready linting and governance for AI-generated code across multiple languages.
+
+## Welcome
+
+**thai-lint** is a modern, enterprise-ready multi-language linter designed specifically for AI-generated code. It focuses on common mistakes and anti-patterns that AI coding assistants frequently introduce—issues that existing linters don't catch or don't handle consistently across languages.
+
+### Quick Links
+
+- **[Quick Start Guide](quick-start.md)** - Get running in 5 minutes
+- **[Configuration Reference](configuration.md)** - Complete config options for all linters
+- **[Troubleshooting Guide](troubleshooting.md)** - Common issues and solutions
+
+## Why thai-lint?
+
+We're not trying to replace the wonderful existing linters like Pylint, ESLint, or Ruff. Instead, thai-lint fills critical gaps:
+
+- **AI-Specific Patterns**: AI assistants have predictable blind spots (excessive nesting, magic numbers, SRP violations) that traditional linters miss
+- **Cross-Language Consistency**: Detects the same anti-patterns across Python, TypeScript, and JavaScript with unified rules
+- **No Existing Solutions**: Issues like excessive nesting depth, file placement violations, and cross-project code duplication lack comprehensive multi-language detection
+- **Governance Layer**: Enforces project-wide structure and organization patterns that AI can't infer from local context
+
+thai-lint complements your existing linting stack by catching the patterns AI tools repeatedly miss.
+
+## Features
+
+### Core Capabilities
+
+- **File Placement Linting** - Enforce project structure and organization
+- **Magic Numbers Linting** - Detect unnamed numeric literals that should be constants
+- **Nesting Depth Linting** - Detect excessive code nesting with AST analysis
+- **SRP Linting** - Detect Single Responsibility Principle violations
+- **DRY Linting** - Detect duplicate code across projects
+- **Pluggable Architecture** - Easy to extend with custom linters
+- **Multi-Language Support** - Python, TypeScript, JavaScript, and more
+- **Flexible Configuration** - YAML/JSON configs with pattern matching
+- **5-Level Ignore System** - Repo, directory, file, method, and line-level ignores
+
+### Deployment Modes
+
+- **CLI Mode** - Full-featured command-line interface
+- **Library API** - Python library for programmatic integration
+- **Docker Support** - Containerized deployment for CI/CD
+
+### Enterprise Features
+
+- **Performance** - <100ms for single files, <5s for 1000 files
+- **Type Safety** - Full type hints and MyPy strict mode
+- **Test Coverage** - 90% coverage with 296+ tests
+- **CI/CD Ready** - Proper exit codes and JSON output
+- **Comprehensive Docs** - Complete documentation and examples
+
+## Installation
+
+### From PyPI
+
+```bash
+pip install thai-lint
+```
+
+### From Source
+
+```bash
+# Clone repository
+git clone https://github.com/be-wise-be-kind/thai-lint.git
+cd thai-lint
+
+# Install dependencies
+pip install -e ".[dev]"
+```
+
+### With Docker
+
+```bash
+# Pull from Docker Hub
+docker pull washad/thailint:latest
+
+# Run CLI
+docker run --rm washad/thailint:latest --help
+```
+
+## Quick Start
+
+### CLI Mode
+
+```bash
+# Check file placement
+thailint file-placement .
+
+# Check for magic numbers
+thailint magic-numbers src/
+
+# Check nesting depth
+thailint nesting src/
+
+# Check for duplicate code
+thailint dry .
+
+# With config file
+thailint dry --config .thailint.yaml src/
+
+# JSON output for CI/CD
+thailint dry --format json src/
+```
+
+See the **[Quick Start Guide](quick-start.md)** for a complete walkthrough.
+
+### Library Mode
+
+```python
+from src import Linter
+
+# Initialize linter
+linter = Linter(config_file='.thailint.yaml')
+
+# Lint directory
+violations = linter.lint('src/', rules=['file-placement'])
+
+# Process results
+if violations:
+    for v in violations:
+        print(f"{v.file_path}: {v.message}")
+```
+
+## Available Linters
+
+### [File Placement Linter](file-placement-linter.md)
+Enforce project structure and organization rules.
+
+### [Magic Numbers Linter](magic-numbers-linter.md)
+Detect unnamed numeric literals that should be named constants.
+
+### [Nesting Depth Linter](nesting-linter.md)
+Detect deeply nested code that reduces readability.
+
+### [SRP Linter](srp-linter.md)
+Detect Single Responsibility Principle violations in classes.
+
+### [DRY Linter](dry-linter.md)
+Detect duplicate code blocks across your project.
+
+## Documentation
+
+- **[Getting Started](getting-started.md)** - Installation and first lint
+- **[Configuration Reference](configuration.md)** - Complete config options (YAML/JSON)
+- **[How to Ignore Violations](how-to-ignore-violations.md)** - Complete guide to all ignore levels
+- **[API Reference](api-reference.md)** - Library API documentation
+- **[CLI Reference](cli-reference.md)** - All CLI commands and options
+- **[Deployment Modes](deployment-modes.md)** - CLI, Library, and Docker usage
+- **[Pre-commit Hooks](pre-commit-hooks.md)** - Automated quality checks
+
+## Support
+
+- **GitHub Issues**: [https://github.com/be-wise-be-kind/thai-lint/issues](https://github.com/be-wise-be-kind/thai-lint/issues)
+- **Repository**: [https://github.com/be-wise-be-kind/thai-lint](https://github.com/be-wise-be-kind/thai-lint)
+- **PyPI**: [https://pypi.org/project/thailint/](https://pypi.org/project/thailint/)
+
+## License
+
+MIT License - see [LICENSE](https://github.com/be-wise-be-kind/thai-lint/blob/main/LICENSE) file for details.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# Python dependencies for building ReadTheDocs documentation
+mkdocs>=1.5.0
+mkdocs-material>=9.5.0
+pymdown-extensions>=10.7.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,80 @@
+# MkDocs configuration for thai-lint documentation
+site_name: thai-lint
+site_description: The AI Linter - Enterprise-ready linting and governance for AI-generated code
+site_author: Steve Jackson
+site_url: https://thai-lint.readthedocs.io
+
+# Repository
+repo_name: be-wise-be-kind/thai-lint
+repo_url: https://github.com/be-wise-be-kind/thai-lint
+edit_uri: edit/main/docs/
+
+# Copyright
+copyright: Copyright &copy; 2024 Steve Jackson
+
+# Configuration
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+
+# Extensions
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+# Page tree
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Quick Start: quick-start.md
+      - Installation: getting-started.md
+      - Configuration: configuration.md
+      - Troubleshooting: troubleshooting.md
+  - Linters:
+      - File Placement: file-placement-linter.md
+      - Magic Numbers: magic-numbers-linter.md
+      - Nesting Depth: nesting-linter.md
+      - Single Responsibility (SRP): srp-linter.md
+      - DRY (Duplicate Code): dry-linter.md
+  - Usage:
+      - CLI Reference: cli-reference.md
+      - API Reference: api-reference.md
+      - Deployment Modes: deployment-modes.md
+      - How to Ignore Violations: how-to-ignore-violations.md
+      - Pre-commit Hooks: pre-commit-hooks.md
+  - Publishing:
+      - Release Workflow: releasing.md
+      - Publishing Checklist: publishing-checklist.md
+  - Advanced:
+      - AI Documentation Standard: ai-doc-standard.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/be-wise-be-kind/thai-lint"
 repository = "https://github.com/be-wise-be-kind/thai-lint"
-documentation = "https://github.com/be-wise-be-kind/thai-lint#readme"
+documentation = "https://thai-lint.readthedocs.io/"
 keywords = [
     "linter",
     "ai",


### PR DESCRIPTION
## Summary

Fixes broken PyPI documentation links by setting up ReadTheDocs for professional documentation hosting.

## Problem

PyPI package page shows broken documentation links because:
- README.md contains relative links to `docs/*.md` files
- The `docs/` folder is excluded from PyPI package distribution
- Result: All documentation links return 404 errors

## Solution

Set up ReadTheDocs to host all documentation with working links.

## Changes

### New Files
- **`.readthedocs.yaml`** - ReadTheDocs build configuration (Python 3.11, MkDocs)
- **`mkdocs.yml`** - MkDocs site configuration with Material theme and navigation
- **`docs/requirements.txt`** - Build dependencies (mkdocs, mkdocs-material, pymdown-extensions)
- **`docs/index.md`** - Documentation landing page

### Updated Files
- **`README.md`** - Replaced ~20 relative `docs/` links with ReadTheDocs URLs
- **`pyproject.toml`** - Updated documentation URL to point to ReadTheDocs
- Added ReadTheDocs status badge to README and docs/index.md

## Benefits

✅ Users can read full documentation directly from PyPI (no 404 errors)
✅ Professional, searchable documentation on ReadTheDocs
✅ All documentation links work correctly
✅ Documentation site: https://thai-lint.readthedocs.io/

## Next Steps

After merging:
1. Import repository to ReadTheDocs account
2. Build will auto-start using `.readthedocs.yaml` config
3. Documentation will be live at https://thai-lint.readthedocs.io/
4. Publish new package version to PyPI with working links

## Testing

- ✅ Pre-commit hooks passed
- ✅ All tests passed (296/296)
- ✅ Linting passed
- ✅ Local MkDocs preview verified (can test with `mkdocs serve`)