### PR TITLE
feat: Integrate magic numbers linter into lint-full workflow

### DIFF
--- a/.thailint.yaml
+++ b/.thailint.yaml
@@ -163,3 +163,9 @@ dry:
   filters:
     keyword_argument_filter: true  # Filter function call keyword arguments (e.g., param=value, ...)
     import_group_filter: true       # Filter import statement groups
+
+# Magic numbers linter configuration
+magic-numbers:
+  enabled: true  # Enable magic number detection
+  allowed_numbers: [-1, 0, 1, 2, 3, 4, 5, 10, 100, 1000]  # Standard preset - numbers acceptable without constants
+  max_small_integer: 10  # Maximum value allowed in range() or enumerate()

--- a/justfile
+++ b/justfile
@@ -36,9 +36,10 @@ help:
     @echo "  just lint-complexity [FILES...] - Complexity analysis (Radon + Xenon + Nesting)"
     @echo "  just lint-placement [PATH]     - File placement linting (dogfooding our own linter)"
     @echo "  just lint-solid [FILES...]     - SOLID principle linting (SRP)"
+    @echo "  just lint-magic-numbers [FILES...] - Magic number detection (unnamed numeric literals)"
     @echo "  just lint-dry                  - DRY principle linting (duplicate code detection)"
     @echo "  just clean-cache               - Clear DRY linter cache"
-    @echo "  just lint-full [FILES...]      - ALL quality checks (includes lint-dry as of PR4)"
+    @echo "  just lint-full [FILES...]      - ALL quality checks (includes magic numbers and DRY)"
     @echo "  just format                    - Auto-fix formatting and linting issues"
     @echo ""
     @echo "Testing:"
@@ -304,6 +305,23 @@ lint-dry +files="src/ tests/":
         fi \
     fi
 
+# Magic numbers linting (detect unnamed numeric literals)
+lint-magic-numbers +files="src/ tests/":
+    @echo ""
+    @echo "{{BLUE}}{{BOLD}}════════════════════════════════════════════════════════════{{NC}}"
+    @echo "{{BOLD}}  MAGIC NUMBERS (Unnamed Numeric Literals){{NC}}"
+    @echo "{{BLUE}}{{BOLD}}════════════════════════════════════════════════════════════{{NC}}"
+    @echo ""
+    @SRC_TARGETS=$(just _get-src-targets {{files}}); \
+    if [ -n "$SRC_TARGETS" ]; then \
+        if poetry run thai-lint magic-numbers $SRC_TARGETS --config .thailint.yaml 2>&1; then \
+            echo "{{GREEN}}✓ Magic numbers checks passed{{NC}}"; \
+        else \
+            echo "{{RED}}✗ Magic numbers checks failed{{NC}}"; \
+            exit 1; \
+        fi \
+    fi
+
 # Clear DRY linter cache
 clean-cache:
     @echo "{{BLUE}}Clearing DRY linter cache...{{NC}}"
@@ -360,6 +378,13 @@ lint-full +files="src/ tests/":
         PASSED+=("SOLID Principles")
     else
         FAILED+=("SOLID Principles")
+    fi
+
+    echo ""
+    if just lint-magic-numbers {{files}}; then
+        PASSED+=("Magic Numbers")
+    else
+        FAILED+=("Magic Numbers")
     fi
 
     echo ""


### PR DESCRIPTION
## Summary

Integrates the magic numbers linter into the `just lint-full` workflow to ensure all numeric literals are properly named as constants.

## Changes

### Configuration
- **Added magic-numbers configuration to `.thailint.yaml`**
  - `enabled: true`
  - `allowed_numbers: [-1, 0, 1, 2, 3, 4, 5, 10, 100, 1000]` (standard preset)
  - `max_small_integer: 10` for range() and enumerate()

### Justfile
- **Created `lint-magic-numbers` recipe** (justfile:308-322)
  - Follows existing linter patterns (lint-solid, lint-dry)
  - Displays formatted section header
  - Runs `poetry run thai-lint magic-numbers` with config
  - Shows pass/fail status with colored output

- **Integrated into `lint-full` recipe** (justfile:383-387)
  - Added as step 6 of 7 (between SOLID and DRY checks)
  - Properly tracked in PASSED/FAILED arrays
  - Displayed in summary section

- **Updated help text** (justfile:39, 42)
  - Added `just lint-magic-numbers [FILES...]` command
  - Updated lint-full description to mention magic numbers

## Test Results

### Magic Numbers Check
```
✓ No violations found
✓ Magic numbers checks passed
```

The codebase already passes all magic numbers checks (0 violations) as it was previously self-dogfooded during the magic numbers linter development (v0.3.0).

### Full Test Suite
```
✓ All 356 tests passed
```

### Full Quality Check
```
✓ Comprehensive Linting
✓ Security Scanning
✓ Complexity Analysis
✓ File Placement
✓ SOLID Principles
✓ Magic Numbers (newly integrated!)
✓ DRY Principles

✅ ALL QUALITY CHECKS PASSED!
```

## Impact

Users running `just lint-full` will now see magic numbers detection as part of the comprehensive quality check. The output shows:

```
════════════════════════════════════════════════════════════
  MAGIC NUMBERS (Unnamed Numeric Literals)
════════════════════════════════════════════════════════════

✓ No violations found
✓ Magic numbers checks passed
```

## Related

- Magic numbers linter was implemented in v0.3.0
- Documentation: `docs/magic-numbers-linter.md`
- Addresses the gap where the linter existed but wasn't integrated into the full workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)