### PR TITLE
docs: Add roadmap for method-should-be-property linter

### DIFF
--- a/.roadmap/planning/method-should-be-property/AI_CONTEXT.md
+++ b/.roadmap/planning/method-should-be-property/AI_CONTEXT.md
@@ -1,0 +1,451 @@
+# Method Should Be Property Linter - AI Context
+
+**Purpose**: AI agent context document for implementing Method Should Be Property Linter
+
+**Scope**: Detection of Python methods that should be converted to @property decorators, following Pythonic conventions
+
+**Overview**: Comprehensive context document for AI agents working on the Method Should Be Property Linter feature.
+    This linter identifies methods that violate Pythonic conventions by using explicit getter methods instead of
+    the @property decorator. Uses AST analysis to detect simple accessor methods, get_* prefixed methods,
+    and simple computed values that would be better expressed as properties.
+
+**Dependencies**: Python AST module, MultiLanguageLintRule base class, pytest for testing
+
+**Exports**: Feature architecture, detection patterns, exclusion rules, integration guidance
+
+**Related**: PR_BREAKDOWN.md for implementation tasks, PROGRESS_TRACKER.md for current status
+
+**Implementation**: AST-based pattern detection with comprehensive exclusion rules to minimize false positives
+
+---
+
+## Overview
+
+The Method Should Be Property Linter detects Python methods that should be converted to `@property` decorators. This fills a gap in the linting ecosystem - no major linter (Pylint, Ruff, SonarQube) implements this check despite it being a well-known Python best practice.
+
+## Project Background
+
+### The Problem
+Python developers coming from Java or other languages often write explicit getter/setter methods:
+
+```python
+# Java-style (anti-pattern in Python)
+class User:
+    def get_name(self):
+        return self._name
+
+    def set_name(self, value):
+        self._name = value
+```
+
+This violates PEP 8 and Pythonic conventions. Python provides the `@property` decorator for this purpose:
+
+```python
+# Pythonic approach
+class User:
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
+```
+
+### Research Findings
+
+| Source | Key Guidance |
+|--------|-------------|
+| [PEP 8](https://peps.python.org/pep-0008/) | "For simple public data attributes, it is best to expose just the attribute name. Use properties to hide functional implementation behind simple data attribute access syntax." |
+| [Pylint #7172](https://github.com/pylint-dev/pylint/issues/7172) | Feature request exists but is marked "Needs PR" - not implemented |
+| [python-course.eu](https://python-course.eu/oop/properties-vs-getters-and-setters.php) | "The Pythonic way to introduce attributes is to make them public. Properties use the @property decorator." |
+
+## Feature Vision
+
+1. **Detect Java-style getters**: Flag `get_*()` methods that should be properties
+2. **Detect simple accessors**: Flag methods that only return `self._attribute`
+3. **Detect simple computed values**: Flag methods with simple arithmetic/string operations
+4. **Minimize false positives**: Comprehensive exclusion rules for legitimate methods
+5. **Provide actionable suggestions**: Tell users exactly how to convert
+
+## Detection Patterns
+
+### Pattern 1: Simple Attribute Return
+Methods that return only a single attribute.
+
+```python
+# DETECT - should be @property
+def name(self):
+    return self._name
+
+def value(self):
+    return self.value
+
+def config(self):
+    return self._settings.config
+```
+
+### Pattern 2: get_* Prefix (Java-Style)
+Methods with `get_` prefix - explicit Java-style getters.
+
+```python
+# DETECT - Java-style anti-pattern
+def get_name(self):
+    return self._name
+
+def get_total(self):
+    return self._count * self._price
+```
+
+### Pattern 3: Simple Computation
+Methods with simple arithmetic or string operations on self attributes.
+
+```python
+# DETECT - simple computed properties
+def area(self):
+    return self._width * self._height
+
+def full_name(self):
+    return f"{self._first} {self._last}"
+
+def is_valid(self):
+    return self._value > 0 and self._value < 100
+
+def display_name(self):
+    return self._name.upper()
+```
+
+### Pattern 4: Chained Attribute Access
+Methods returning nested attribute access.
+
+```python
+# DETECT - delegation pattern
+def database(self):
+    return self._connection.database
+
+def settings(self):
+    return self._config.settings.general
+```
+
+## Exclusion Rules
+
+### Rule 1: Methods with Parameters
+Properties cannot accept arguments. Any method with parameters beyond `self` is excluded.
+
+```python
+# EXCLUDE - has parameters
+def get_item(self, index):
+    return self._items[index]
+
+def value_with_default(self, default=None):
+    return self._value or default
+```
+
+### Rule 2: Methods with Assignments (Side Effects)
+Methods that modify state should not be properties.
+
+```python
+# EXCLUDE - modifies state
+def cached_value(self):
+    self._cached = True  # Assignment!
+    return self._value
+
+def increment_and_get(self):
+    self._count += 1  # Augmented assignment!
+    return self._count
+```
+
+### Rule 3: Methods with Loops
+Loops indicate iteration, which is typically not property-like.
+
+```python
+# EXCLUDE - contains loop
+def items(self):
+    for item in self._data:
+        yield item
+
+def filtered_values(self):
+    result = []
+    for v in self._values:
+        if v > 0:
+            result.append(v)
+    return result
+```
+
+### Rule 4: Methods with try/except
+Error handling indicates complexity beyond property access.
+
+```python
+# EXCLUDE - error handling
+def safe_value(self):
+    try:
+        return self._value
+    except AttributeError:
+        return None
+```
+
+### Rule 5: Methods with External Function Calls
+Calling external functions may have side effects.
+
+```python
+# EXCLUDE - external function call
+def formatted_date(self):
+    return format_date(self._date)  # External function!
+
+def validated_value(self):
+    validate(self._value)  # External function!
+    return self._value
+```
+
+**Exception**: Calls to `self.*` methods are allowed if they are also simple accessors.
+
+### Rule 6: Decorated Methods
+Certain decorators indicate the method has special behavior.
+
+```python
+# EXCLUDE - decorated
+@staticmethod
+def create_default():
+    return MyClass()
+
+@classmethod
+def from_dict(cls, data):
+    return cls(**data)
+
+@abstractmethod
+def compute(self):
+    pass
+
+@property  # Already a property!
+def name(self):
+    return self._name
+
+@functools.cached_property
+def expensive_value(self):
+    return compute_expensive()
+```
+
+### Rule 7: Complex Method Bodies
+Methods with more than 3 statements are too complex for properties.
+
+```python
+# EXCLUDE - too many statements
+def processed_value(self):
+    value = self._raw_value
+    value = value.strip()
+    value = value.lower()
+    value = value.replace("-", "_")
+    return value
+```
+
+### Rule 8: Dunder Methods
+Special methods like `__str__`, `__repr__` should not be flagged.
+
+```python
+# EXCLUDE - dunder method
+def __str__(self):
+    return self._name
+
+def __repr__(self):
+    return f"MyClass({self._value})"
+```
+
+### Rule 9: Test Files
+Methods in test files are not production code.
+
+```python
+# EXCLUDE - in test_*.py or *_test.py files
+def get_mock_value(self):
+    return self._mock_data
+```
+
+### Rule 10: Methods Returning None
+Methods with no return or returning None are not accessors.
+
+```python
+# EXCLUDE - no return value
+def initialize(self):
+    pass
+
+def log_value(self):
+    print(self._value)
+    return None
+```
+
+### Rule 11: Async Methods
+Methods with `await` perform I/O and should not be properties.
+
+```python
+# EXCLUDE - async/await
+async def data(self):
+    return await self._fetch_data()
+```
+
+## AST Analysis Strategy
+
+### Method Detection Flow
+
+```
+1. Parse Python file into AST
+2. Walk AST to find all class definitions
+3. For each class, iterate over methods (FunctionDef nodes)
+4. For each method, check:
+   a. Takes only 'self' parameter? (check args)
+   b. Has simple body? (1-3 statements, ends with Return)
+   c. Returns a value? (not None, not missing)
+   d. No side effects? (no Assign, AugAssign, For, While, Try, Await)
+   e. No excluded decorators? (staticmethod, classmethod, abstractmethod, property)
+   f. Not a dunder method? (not __*__)
+5. If all checks pass, flag as violation
+```
+
+### AST Node Types to Check
+
+| Node Type | Check For |
+|-----------|-----------|
+| `ast.FunctionDef` | Method definitions |
+| `ast.arguments` | Parameter count (should be 1 - self only) |
+| `ast.Return` | Return statement (body should end with this) |
+| `ast.Assign` | State modification (exclude) |
+| `ast.AugAssign` | Augmented assignment (exclude) |
+| `ast.For` | Loop (exclude) |
+| `ast.While` | Loop (exclude) |
+| `ast.Try` | Error handling (exclude) |
+| `ast.Call` | Function calls (check if external) |
+| `ast.Await` | Async operation (exclude) |
+| `ast.Attribute` | self.* access (allowed) |
+
+### Violation Classification
+
+Based on detection pattern, generate appropriate message:
+
+| Pattern | Message Template |
+|---------|-----------------|
+| `get_*` prefix | "Method 'get_name()' should be a @property 'name' - Java-style getter detected" |
+| Simple return | "Method 'value()' should be a @property - returns only 'self._value'" |
+| Computed value | "Method 'area()' should be a @property - simple stateless computation" |
+
+## Integration Points
+
+### With Existing Code
+
+| Component | Integration |
+|-----------|-------------|
+| `src/core/base.py` | Inherit from `MultiLanguageLintRule` |
+| `src/core/types.py` | Use `Violation` dataclass |
+| `src/cli.py` | Register `method-property` command |
+| `src/orchestrator/` | Auto-discovered via RuleRegistry |
+
+### Pattern Reference
+
+Follow the structure of `src/linters/print_statements/`:
+
+```
+print_statements/
+├── __init__.py          → Package exports
+├── config.py            → Configuration dataclass
+├── linter.py            → Main rule class
+├── python_analyzer.py   → AST analysis
+├── typescript_analyzer.py (not needed for this linter)
+└── violation_builder.py → Violation message creation
+```
+
+## Technical Constraints
+
+1. **Python Only**: This linter targets Python code. TypeScript has different conventions.
+2. **AST Limitation**: Can only analyze syntactically valid Python files.
+3. **No Runtime Analysis**: Cannot detect runtime side effects (only static analysis).
+4. **Performance**: Keep analysis fast - avoid expensive operations.
+
+## AI Agent Guidance
+
+### When Implementing Detection
+
+1. Start with the most common pattern (get_* prefix)
+2. Build exclusion rules incrementally with tests
+3. Prefer false negatives over false positives
+4. Each exclusion rule should have tests
+
+### When Writing Tests
+
+1. Write tests FIRST (TDD red phase)
+2. Each detection pattern needs positive and negative tests
+3. Each exclusion rule needs tests proving it works
+4. Include edge cases (empty files, syntax errors, Unicode)
+
+### Common Patterns
+
+**Creating a Violation**:
+```python
+violation = Violation(
+    rule_id="method-property.should-be-property",
+    file_path=str(context.file_path),
+    line=method.lineno,
+    column=method.col_offset,
+    message=f"Method '{method.name}()' should be a @property",
+    suggestion="Convert to @property decorator for Pythonic attribute access"
+)
+```
+
+**Checking for Side Effects**:
+```python
+def _has_side_effects(self, method: ast.FunctionDef) -> bool:
+    """Check for assignments, loops, try/except, external calls, await."""
+    for node in ast.walk(method):
+        if isinstance(node, (ast.Assign, ast.AugAssign)):
+            return True
+        if isinstance(node, (ast.For, ast.While)):
+            return True
+        if isinstance(node, ast.Try):
+            return True
+        if isinstance(node, ast.Await):
+            return True
+        if isinstance(node, ast.Call) and not self._is_self_call(node):
+            return True
+    return False
+```
+
+## Risk Mitigation
+
+### False Positive Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Methods with legitimate reasons to not be properties | Comprehensive exclusion rules |
+| Performance-critical code | Exclude methods calling external functions |
+| Framework integration | Test with real-world codebases (dogfooding) |
+
+### Implementation Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Complex AST analysis | Follow existing linter patterns |
+| Missing edge cases | Comprehensive test suite (40+ tests) |
+| Performance issues | Keep analysis simple, avoid recursion |
+
+## Future Enhancements
+
+1. **set_* Detection**: Detect `set_*` methods that should use `@property.setter`
+2. **TypeScript Support**: Extend to TypeScript getter/setter patterns
+3. **Auto-fix**: Provide automatic code transformation
+4. **IDE Integration**: VS Code extension for real-time feedback
+
+## Rule Configuration
+
+### Default Configuration
+```yaml
+method-property:
+  enabled: true
+  max_body_statements: 3
+  ignore:
+    - "tests/*"
+    - "**/test_*.py"
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | true | Enable/disable the linter |
+| `max_body_statements` | int | 3 | Maximum statements in method body |
+| `ignore` | list[str] | [] | Glob patterns for files to skip |

--- a/.roadmap/planning/method-should-be-property/PROGRESS_TRACKER.md
+++ b/.roadmap/planning/method-should-be-property/PROGRESS_TRACKER.md
@@ -1,0 +1,258 @@
+# Method Should Be Property Linter - Progress Tracker & AI Agent Handoff Document
+
+**Purpose**: Primary AI agent handoff document for Method Should Be Property Linter with current progress tracking and implementation guidance
+
+**Scope**: Development of a linter to detect Python methods that should be converted to @property decorators, following Pythonic conventions
+
+**Overview**: Primary handoff document for AI agents working on the Method Should Be Property Linter feature.
+    Tracks current implementation progress, provides next action guidance, and coordinates AI agent work across
+    multiple pull requests. Contains current status, prerequisite validation, PR dashboard, detailed checklists,
+    implementation strategy, success metrics, and AI agent instructions. Essential for maintaining development
+    continuity and ensuring systematic feature implementation with proper validation and testing.
+
+**Dependencies**: BaseLintRule interface, Python AST, pytest testing framework
+
+**Exports**: Progress tracking, implementation guidance, AI agent coordination, and feature development roadmap
+
+**Related**: AI_CONTEXT.md for feature overview, PR_BREAKDOWN.md for detailed tasks
+
+**Implementation**: Progress-driven coordination with systematic validation, checklist management, and AI agent handoff procedures
+
+---
+
+## Document Purpose
+This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the Method Should Be Property Linter feature. When starting work on any PR, the AI agent should:
+1. **Read this document FIRST** to understand current progress and feature requirements
+2. **Check the "Next PR to Implement" section** for what to do
+3. **Reference the linked documents** for detailed instructions
+4. **Update this document** after completing each PR
+
+## Current Status
+**Current PR**: Planning Complete - Ready for PR1
+**Infrastructure State**: Roadmap created, awaiting implementation
+**Feature Target**: Production-ready method-should-be-property linter for Python
+
+## Required Documents Location
+```
+.roadmap/planning/method-should-be-property/
+├── AI_CONTEXT.md          # Overall feature architecture and context
+├── PR_BREAKDOWN.md        # Detailed instructions for each PR
+├── PROGRESS_TRACKER.md    # THIS FILE - Current progress and handoff notes
+```
+
+## Next PR to Implement
+
+### START HERE: PR1 - Test Suite for Python Method Detection
+
+**Quick Summary**:
+Create comprehensive test suite for detecting Python methods that should be @property decorators. Tests should cover all detection patterns and exclusion rules defined in AI_CONTEXT.md.
+
+**Pre-flight Checklist**:
+- [ ] Read PR_BREAKDOWN.md Section PR1 for detailed instructions
+- [ ] Read AI_CONTEXT.md for detection patterns and exclusions
+- [ ] Review existing test patterns in `tests/unit/linters/print_statements/`
+- [ ] Ensure local development environment is set up (`just install`)
+
+**Prerequisites Complete**:
+- [x] Research on best practices complete (PEP 8, Pylint discussions)
+- [x] Confirmed no existing major linter implements this rule
+- [x] Roadmap documents created
+
+---
+
+## Overall Progress
+**Total Completion**: 0% (0/5 PRs completed)
+
+```
+[                                        ] 0% Complete
+```
+
+---
+
+## PR Status Dashboard
+
+| PR | Title | Status | Completion | Complexity | Priority | Notes |
+|----|-------|--------|------------|------------|----------|-------|
+| PR1 | Test Suite for Python Method Detection | Not Started | 0% | Medium | P0 | TDD red phase - tests must fail initially |
+| PR2 | Python Implementation | Not Started | 0% | Medium | P0 | TDD green phase - make tests pass |
+| PR3 | CLI Integration | Not Started | 0% | Low | P0 | Add `thailint method-property` command |
+| PR4 | Self-Dogfooding: Lint Own Codebase | Not Started | 0% | Medium | P1 | Validate linter on thai-lint codebase |
+| PR5 | Documentation & Publishing | Not Started | 0% | Low | P1 | Docs for ReadTheDocs and PyPI users |
+
+### Status Legend
+- Not Started
+- In Progress
+- Complete
+- Blocked
+- Cancelled
+
+---
+
+## PR1: Test Suite for Python Method Detection
+
+### Scope
+Write comprehensive test suite for Python method-should-be-property detection using TDD approach.
+
+### Success Criteria
+- [ ] Tests organized in `tests/unit/linters/method_property/`
+- [ ] Tests follow pytest and project conventions
+- [ ] All tests fail initially (TDD red phase)
+- [ ] Coverage includes all detection patterns from AI_CONTEXT.md
+- [ ] Coverage includes all exclusion rules from AI_CONTEXT.md
+- [ ] Tests pass linting (Pylint 10.00/10, Xenon A-grade)
+
+### Key Test Categories
+1. **Basic Detection** - Simple attribute returns, get_* prefix, computed values
+2. **Exclusion Rules** - Parameters, side effects, decorators, test files
+3. **Configuration** - Custom thresholds, ignore patterns
+4. **Ignore Directives** - Line-level, method-level ignores
+5. **Edge Cases** - Empty files, Unicode, syntax errors
+
+---
+
+## PR2: Python Implementation
+
+### Scope
+Implement Python method-should-be-property detection to pass PR1 tests.
+
+### Success Criteria
+- [ ] `src/linters/method_property/` module created
+- [ ] `MethodPropertyRule` class implements `MultiLanguageLintRule`
+- [ ] Python AST analysis detects all patterns from AI_CONTEXT.md
+- [ ] All exclusion rules properly implemented
+- [ ] Configuration support for thresholds and ignore patterns
+- [ ] All PR1 tests pass
+- [ ] Linting passes (`just lint-full` exits with code 0)
+
+---
+
+## PR3: CLI Integration
+
+### Scope
+Add CLI command for method-property linter.
+
+### Success Criteria
+- [ ] `thailint method-property` command registered in `src/cli.py`
+- [ ] Supports `--config`, `--format`, `--recursive` options
+- [ ] All three output formats work (text, json, sarif)
+- [ ] Help text with examples
+- [ ] Exit codes: 0 (clean), 1 (violations), 2 (error)
+
+---
+
+## PR4: Self-Dogfooding: Lint Own Codebase
+
+### Scope
+Run method-property linter on thai-lint codebase and address violations.
+
+### Success Criteria
+- [ ] Linter runs on entire codebase
+- [ ] All violations either fixed or documented with ignore directives
+- [ ] Linting passes (`just lint-full` exits with code 0)
+- [ ] Tests still pass
+
+---
+
+## PR5: Documentation & Publishing
+
+### Scope
+Complete documentation for ReadTheDocs and PyPI users.
+
+### Success Criteria
+- [ ] `docs/method-property-linter.md` created (comprehensive user guide)
+- [ ] `mkdocs.yml` updated with nav entry under Linters section
+- [ ] `README.md` updated with linter in feature list
+- [ ] `docs/cli-reference.md` updated with command documentation
+- [ ] `docs/configuration.md` updated with configuration section
+- [ ] `docs/index.md` updated with linter count/list
+- [ ] All tests pass
+- [ ] Full linting passes
+
+---
+
+## Implementation Strategy
+
+**TDD Approach**:
+1. Write failing tests first (red phase)
+2. Implement minimal code to pass tests (green phase)
+3. Refactor for quality (refactor phase)
+4. Run full linting to ensure A-grade complexity
+5. Dogfood the linter on own codebase
+
+**Quality Focus**:
+- All code must pass `just lint-full` (Pylint 10.00/10, Xenon A-grade)
+- Tests must be comprehensive and maintainable
+- Follow existing linter patterns for consistency
+
+## Success Metrics
+
+### Technical Metrics
+- [ ] Test coverage >= 80%
+- [ ] All linting passes (Pylint 10.00/10)
+- [ ] All complexity A-grade (Xenon)
+- [ ] No failing tests
+- [ ] CI/CD pipeline green
+
+### Feature Metrics
+- [ ] Detects all patterns defined in AI_CONTEXT.md
+- [ ] Respects all exclusion rules
+- [ ] Supports ignore directives (line, method, file-level)
+- [ ] Configurable thresholds
+- [ ] False positive rate < 5%
+
+## Update Protocol
+
+After completing each PR:
+1. Update the PR status to Complete
+2. Fill in completion percentage (100%)
+3. Add commit hash to notes: `(commit abc1234)`
+4. Update the "Next PR to Implement" section
+5. Update overall progress percentage
+6. Commit changes to the progress document
+
+## Notes for AI Agents
+
+### Critical Context
+- **Pythonic Philosophy**: Properties are preferred over getter/setter methods in Python (PEP 8)
+- **No Existing Linter**: Pylint issue #7172 requests this feature but is not implemented
+- **TDD Mandatory**: Tests must be written and failing before implementation
+- **Follow Patterns**: Study `src/linters/print_statements/` for structure
+
+### Common Pitfalls to Avoid
+- Do not flag methods with parameters beyond `self`
+- Do not flag methods with side effects (assignments, loops, try/except)
+- Do not flag staticmethod/classmethod/abstractmethod
+- Do not skip TDD - tests must come first
+- Do not add suppression comments without user permission
+- Do not commit code that doesn't pass `just lint-full`
+
+### Resources
+- **Detection Patterns**: AI_CONTEXT.md - comprehensive detection and exclusion rules
+- **PR Details**: PR_BREAKDOWN.md - step-by-step implementation instructions
+- **Test Guide**: `.ai/howtos/how-to-write-tests.md`
+- **Linting Guide**: `.ai/howtos/how-to-fix-linting-errors.md`
+- **Linter Guide**: `.ai/howtos/how-to-add-linter.md`
+- **Pattern Reference**: `src/linters/print_statements/` (similar structure)
+
+### Research Summary
+
+**Best Practices from Web Research:**
+
+| Source | Key Guidance |
+|--------|-------------|
+| PEP 8 | Expose simple attributes directly; use properties when functional behavior needed; avoid expensive operations in properties |
+| Pylint #7172 | Feature request for this rule exists but is NOT implemented - needs PR |
+| python-course.eu | Properties preferred; use methods only for complex validation, external API compatibility, or when extra parameters needed |
+
+## Definition of Done
+
+The feature is considered complete when:
+- [ ] All 5 PRs merged to main
+- [ ] Python method-should-be-property detection working
+- [ ] thai-lint codebase passes its own method-property linter
+- [ ] Documentation complete (docs/method-property-linter.md)
+- [ ] All tests passing
+- [ ] All linting passing (Pylint 10.00/10, Xenon A-grade)
+- [ ] CLI integration complete (`thailint method-property` command functional)
+- [ ] ReadTheDocs documentation updated (mkdocs.yml, index.md)
+- [ ] README.md updated with feature

--- a/.roadmap/planning/method-should-be-property/PR_BREAKDOWN.md
+++ b/.roadmap/planning/method-should-be-property/PR_BREAKDOWN.md
@@ -1,0 +1,489 @@
+# Method Should Be Property Linter - PR Breakdown
+
+**Purpose**: Detailed implementation breakdown of Method Should Be Property Linter into manageable, atomic pull requests
+
+**Scope**: Complete feature implementation from test suite through documentation and publishing
+
+**Overview**: Comprehensive breakdown of the Method Should Be Property Linter into 5 manageable, atomic
+    pull requests. Each PR is designed to be self-contained, testable, and maintains application functionality
+    while incrementally building toward the complete feature. Includes detailed implementation steps, file
+    structures, testing requirements, and success criteria for each PR.
+
+**Dependencies**: BaseLintRule interface, Python AST, pytest, Click CLI framework
+
+**Exports**: PR implementation plans, file structures, testing strategies, and success criteria for each development phase
+
+**Related**: AI_CONTEXT.md for feature overview, PROGRESS_TRACKER.md for status tracking
+
+**Implementation**: Atomic PR approach with TDD methodology and comprehensive testing validation
+
+---
+
+## Overview
+This document breaks down the Method Should Be Property Linter feature into manageable, atomic PRs. Each PR is designed to be:
+- Self-contained and testable
+- Maintains a working application
+- Incrementally builds toward the complete feature
+- Revertible if needed
+
+---
+
+## PR1: Test Suite for Python Method Detection
+
+### Scope
+Write comprehensive test suite for Python method-should-be-property detection using TDD approach. All tests should fail initially (red phase).
+
+### Files to Create
+
+```
+tests/unit/linters/method_property/
+├── __init__.py
+├── conftest.py                    # Shared fixtures
+├── test_basic_detection.py        # Core detection tests
+├── test_exclusion_rules.py        # Tests for what NOT to flag
+├── test_configuration.py          # Config loading and defaults
+├── test_ignore_directives.py      # Inline ignore support
+├── test_edge_cases.py             # Edge cases and error handling
+└── test_violation_details.py      # Message and suggestion validation
+```
+
+### Test Categories and Coverage
+
+#### 1. Basic Detection Tests (`test_basic_detection.py`)
+```python
+class TestSimpleAttributeReturn:
+    """Tests for methods returning self._attribute or self.attribute"""
+    def test_detects_return_private_attribute(self):
+        # def name(self): return self._name
+    def test_detects_return_public_attribute(self):
+        # def value(self): return self.value
+    def test_detects_return_nested_attribute(self):
+        # def config(self): return self._settings.config
+
+class TestGetPrefixMethods:
+    """Tests for get_* prefixed methods (Java-style)"""
+    def test_detects_get_prefix_simple(self):
+        # def get_name(self): return self._name
+    def test_detects_get_prefix_computed(self):
+        # def get_total(self): return self._a + self._b
+
+class TestSimpleComputation:
+    """Tests for simple computed property candidates"""
+    def test_detects_arithmetic_computation(self):
+        # def area(self): return self._w * self._h
+    def test_detects_string_formatting(self):
+        # def full_name(self): return f"{self._first} {self._last}"
+    def test_detects_boolean_expression(self):
+        # def is_valid(self): return self._value > 0
+```
+
+#### 2. Exclusion Rules Tests (`test_exclusion_rules.py`)
+```python
+class TestParameterExclusions:
+    """Methods with parameters should NOT be flagged"""
+    def test_ignores_method_with_required_param(self):
+        # def get_item(self, index): return self._items[index]
+    def test_ignores_method_with_default_param(self):
+        # def get_value(self, default=None): ...
+
+class TestSideEffectExclusions:
+    """Methods with side effects should NOT be flagged"""
+    def test_ignores_method_with_assignment(self):
+        # def value(self): self._cached = True; return self._value
+    def test_ignores_method_with_augmented_assignment(self):
+        # def count(self): self._count += 1; return self._count
+    def test_ignores_method_with_loop(self):
+        # def items(self): for i in self._data: yield i
+    def test_ignores_method_with_try_except(self):
+        # def safe_value(self): try: return self._v except: return None
+
+class TestDecoratorExclusions:
+    """Decorated methods should NOT be flagged"""
+    def test_ignores_staticmethod(self):
+    def test_ignores_classmethod(self):
+    def test_ignores_abstractmethod(self):
+    def test_ignores_property_already(self):
+    def test_ignores_cached_property(self):
+
+class TestComplexBodyExclusions:
+    """Complex method bodies should NOT be flagged"""
+    def test_ignores_body_over_3_statements(self):
+    def test_ignores_method_with_external_call(self):
+    def test_ignores_method_with_await(self):
+
+class TestSpecialCases:
+    """Special cases that should NOT be flagged"""
+    def test_ignores_dunder_methods(self):
+        # def __str__(self): return self._name
+    def test_ignores_test_files(self):
+    def test_ignores_returns_none(self):
+    def test_ignores_no_return(self):
+```
+
+#### 3. Configuration Tests (`test_configuration.py`)
+```python
+class TestConfigurationDefaults:
+    """Test default configuration values"""
+    def test_default_enabled_true(self):
+    def test_default_max_body_statements(self):
+    def test_default_ignore_patterns(self):
+
+class TestConfigurationLoading:
+    """Test configuration loading from various sources"""
+    def test_loads_from_context_config(self):
+    def test_loads_from_metadata(self):
+    def test_loads_from_yaml_file(self):
+
+class TestConfigurationOverrides:
+    """Test configuration option overrides"""
+    def test_custom_max_body_statements(self):
+    def test_custom_ignore_patterns(self):
+    def test_disabled_linter(self):
+```
+
+#### 4. Ignore Directives Tests (`test_ignore_directives.py`)
+```python
+class TestInlineIgnore:
+    """Test inline ignore directives"""
+    def test_respects_thailint_ignore_specific(self):
+        # def get_name(self): return self._name  # thailint: ignore[method-property]
+    def test_respects_thailint_ignore_generic(self):
+        # def get_name(self): return self._name  # thailint: ignore
+    def test_respects_noqa(self):
+        # def get_name(self): return self._name  # noqa
+```
+
+#### 5. Edge Cases Tests (`test_edge_cases.py`)
+```python
+class TestEdgeCases:
+    """Test edge cases and error handling"""
+    def test_handles_empty_file(self):
+    def test_handles_syntax_error(self):
+    def test_handles_unicode_content(self):
+    def test_handles_no_classes(self):
+    def test_handles_nested_classes(self):
+    def test_handles_multiple_classes(self):
+```
+
+#### 6. Violation Details Tests (`test_violation_details.py`)
+```python
+class TestViolationMessages:
+    """Test violation message formatting"""
+    def test_get_prefix_message(self):
+        # Should suggest: "Method 'get_name()' should be a @property 'name'"
+    def test_simple_return_message(self):
+        # Should suggest: "Method 'value()' should be a @property"
+    def test_computed_value_message(self):
+        # Should suggest: "Method 'area()' should be a @property"
+
+class TestViolationMetadata:
+    """Test violation metadata correctness"""
+    def test_correct_line_number(self):
+    def test_correct_column_number(self):
+    def test_correct_rule_id(self):
+    def test_correct_severity(self):
+```
+
+### Success Criteria
+- [ ] 40+ tests created covering all categories
+- [ ] All tests fail initially (TDD red phase)
+- [ ] Tests pass linting (Pylint 10.00/10, Xenon A-grade)
+- [ ] Tests follow project conventions (fixtures, naming)
+
+---
+
+## PR2: Python Implementation
+
+### Scope
+Implement Python method-should-be-property detection to pass PR1 tests.
+
+### Files to Create
+
+```
+src/linters/method_property/
+├── __init__.py                    # Package exports
+├── linter.py                      # MethodPropertyRule class
+├── config.py                      # MethodPropertyConfig dataclass
+├── python_analyzer.py             # AST-based method analysis
+└── violation_builder.py           # Violation message creation
+```
+
+### Module Design
+
+#### `__init__.py`
+```python
+"""Method Property Linter package exports."""
+from .linter import MethodPropertyRule
+from .config import MethodPropertyConfig
+
+__all__ = ["MethodPropertyRule", "MethodPropertyConfig"]
+```
+
+#### `config.py`
+```python
+@dataclass
+class MethodPropertyConfig:
+    """Configuration for method-property linter."""
+    enabled: bool = True
+    max_body_statements: int = 3
+    ignore: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, config: dict, language: str | None = None) -> "MethodPropertyConfig":
+        """Load configuration from dictionary."""
+```
+
+#### `python_analyzer.py`
+Key methods to implement:
+```python
+class PythonMethodAnalyzer:
+    """Analyzes Python methods for property candidacy."""
+
+    def find_property_candidates(self, tree: ast.AST) -> list[PropertyCandidate]:
+        """Find all methods that should be properties."""
+
+    def _is_property_candidate(self, method: ast.FunctionDef) -> bool:
+        """Check if method should be a property."""
+
+    def _takes_only_self(self, method: ast.FunctionDef) -> bool:
+        """Check if method takes only self parameter."""
+
+    def _has_simple_body(self, method: ast.FunctionDef) -> bool:
+        """Check if body is 1-3 statements ending with return."""
+
+    def _returns_value(self, method: ast.FunctionDef) -> bool:
+        """Check if method returns a non-None value."""
+
+    def _has_side_effects(self, method: ast.FunctionDef) -> bool:
+        """Check for assignments, loops, try/except, external calls."""
+
+    def _is_excluded_decorator(self, method: ast.FunctionDef) -> bool:
+        """Check for @staticmethod, @classmethod, @abstractmethod, @property."""
+
+    def _is_dunder_method(self, method: ast.FunctionDef) -> bool:
+        """Check if method is a dunder method (__str__, etc.)."""
+```
+
+#### `linter.py`
+```python
+class MethodPropertyRule(MultiLanguageLintRule):
+    """Detects methods that should be @property decorators."""
+
+    @property
+    def rule_id(self) -> str:
+        return "method-property.should-be-property"
+
+    @property
+    def rule_name(self) -> str:
+        return "Method Should Be Property"
+
+    @property
+    def description(self) -> str:
+        return "Method should be converted to @property decorator"
+
+    def _check_python(self, context: BaseLintContext, config: MethodPropertyConfig) -> list[Violation]:
+        """Check Python code for property candidates."""
+```
+
+### Success Criteria
+- [ ] All PR1 tests pass (40+ tests)
+- [ ] Linting passes (`just lint-full` exits with code 0)
+- [ ] Pylint score exactly 10.00/10
+- [ ] Xenon complexity A-grade
+- [ ] MyPy passes with no errors
+
+---
+
+## PR3: CLI Integration
+
+### Scope
+Add CLI command for method-property linter.
+
+### Files to Modify
+
+- `src/cli.py` - Add `method-property` command
+
+### Command Implementation
+
+```python
+@cli.command("method-property")
+@click.argument("paths", nargs=-1, type=click.Path())
+@click.option("--config", "-c", "config_file", type=click.Path(), help="Path to config file")
+@format_option  # Supports text, json, sarif
+@click.option("--recursive/--no-recursive", default=True, help="Scan directories recursively")
+@click.pass_context
+def method_property(ctx, paths, config_file, format, recursive):
+    """Check for methods that should be @property decorators.
+
+    Detects Python methods that could be converted to properties:
+    - Methods returning only self._attribute
+    - get_* prefixed methods (Java-style)
+    - Simple computed values
+
+    Examples:
+        thailint method-property src/
+        thailint method-property --format json src/
+        thailint method-property --format sarif src/ > report.sarif
+    """
+```
+
+### Success Criteria
+- [ ] Command registered and appears in `thailint --help`
+- [ ] `thailint method-property --help` shows help text
+- [ ] Text output format works
+- [ ] JSON output format works
+- [ ] SARIF output format works (SARIF v2.1.0 compliant)
+- [ ] Exit codes: 0 (clean), 1 (violations), 2 (error)
+
+---
+
+## PR4: Self-Dogfooding
+
+### Scope
+Run method-property linter on thai-lint codebase and fix violations.
+
+### Process
+
+1. **Run linter on codebase**:
+   ```bash
+   thailint method-property src/
+   ```
+
+2. **Categorize violations**:
+   - True positives to fix
+   - False positives (add to exclusion rules or tests)
+   - Legitimate exceptions (add ignore directive with justification)
+
+3. **Fix violations**:
+   - Convert appropriate methods to @property
+   - Add ignore directives where necessary (with user permission)
+   - Update tests if false positives found
+
+### Success Criteria
+- [ ] Linter runs on entire `src/` directory
+- [ ] All violations addressed (fixed or documented)
+- [ ] No false positives remain (or exclusion rules updated)
+- [ ] All tests still pass
+- [ ] `just lint-full` passes
+
+---
+
+## PR5: Documentation & Publishing
+
+### Scope
+Complete documentation for ReadTheDocs and PyPI users.
+
+### Files to Create
+
+#### `docs/method-property-linter.md`
+Comprehensive user guide following pattern from `docs/magic-numbers-linter.md`:
+
+```markdown
+# Method Property Linter
+
+**Purpose**: Guide to using the method-property linter for detecting methods that should be @property decorators
+
+**Scope**: Configuration, usage, refactoring patterns, and best practices
+
+## Overview
+[Description of what the linter does and why it matters]
+
+## Configuration
+[YAML and JSON configuration examples]
+
+## CLI Usage
+[Command examples with all options]
+
+## Detection Patterns
+[Examples of what gets flagged]
+
+## Exclusion Rules
+[What doesn't get flagged and why]
+
+## Refactoring Guide
+[How to convert methods to properties]
+
+## Ignore Patterns
+[How to suppress violations]
+
+## Integration with CI/CD
+[SARIF output usage]
+
+## Troubleshooting
+[Common issues and solutions]
+```
+
+### Files to Modify
+
+#### `mkdocs.yml`
+Add nav entry:
+```yaml
+nav:
+  - Linters:
+      - Method Property: method-property-linter.md  # Add this line
+```
+
+#### `README.md`
+- Add to linter list in features section
+- Add quick example
+
+#### `docs/cli-reference.md`
+Add command documentation
+
+#### `docs/configuration.md`
+Add configuration section
+
+#### `docs/index.md`
+Update linter count and list
+
+### Success Criteria
+- [ ] `docs/method-property-linter.md` created (comprehensive guide)
+- [ ] `mkdocs.yml` updated with nav entry
+- [ ] `README.md` updated with linter in feature list
+- [ ] `docs/cli-reference.md` updated
+- [ ] `docs/configuration.md` updated
+- [ ] `docs/index.md` updated
+- [ ] Documentation builds without errors (`mkdocs build`)
+- [ ] All tests pass
+- [ ] `just lint-full` passes
+
+---
+
+## Implementation Guidelines
+
+### Code Standards
+- All files must have proper headers per `.ai/docs/FILE_HEADER_STANDARDS.md`
+- Follow existing linter patterns (see `src/linters/print_statements/`)
+- Use type hints throughout
+- Docstrings for all public functions (Google-style)
+
+### Testing Requirements
+- Minimum 40 tests for PR1
+- Test coverage >= 80%
+- Tests must pass Pylint 10.00/10
+- Tests must be independent and deterministic
+
+### Documentation Standards
+- Follow header format from `.ai/docs/FILE_HEADER_STANDARDS.md`
+- Use atemporal language (no "currently", "now", "new")
+- Include code examples for all features
+- Cross-reference related documentation
+
+### Output Format Requirements (Mandatory)
+- Text format (default): Human-readable console output
+- JSON format: Machine-readable structured output
+- SARIF format: SARIF v2.1.0 for CI/CD integration (see `.ai/docs/SARIF_STANDARDS.md`)
+
+---
+
+## Success Metrics
+
+### Launch Metrics
+- All 5 PRs merged to main
+- Zero violations in thai-lint codebase (or documented exceptions)
+- Documentation complete and accessible
+
+### Ongoing Metrics
+- False positive rate < 5%
+- No regressions in existing tests
+- Positive user feedback


### PR DESCRIPTION
## Summary

- Add planning documents for a new linter that detects Python methods that should be converted to `@property` decorators
- This fills a gap in the linting ecosystem - no major linter (Pylint, Ruff, SonarQube) currently implements this check
- Based on research of PEP 8, Pylint issue #7172, and Python best practices

## Roadmap Documents

| Document | Purpose |
|----------|---------|
| `PROGRESS_TRACKER.md` | Primary AI agent handoff - status tracking, 5 PRs defined |
| `PR_BREAKDOWN.md` | Detailed implementation instructions with test categories |
| `AI_CONTEXT.md` | Feature architecture, detection patterns, exclusion rules |

## Detection Patterns (AST-Based)

| Pattern | Example |
|---------|---------|
| Simple attribute return | `def name(self): return self._name` |
| `get_*` prefix (Java-style) | `def get_name(self): return self._name` |
| Simple computation | `def area(self): return self._w * self._h` |
| String formatting | `def full_name(self): return f"{self._first} {self._last}"` |

## Implementation Plan (5 PRs)

1. **PR1**: Test Suite - TDD red phase (40+ tests)
2. **PR2**: Python Implementation - AST-based detection
3. **PR3**: CLI Integration - `thailint method-property` command
4. **PR4**: Self-Dogfooding - Validate on thai-lint codebase
5. **PR5**: Documentation - ReadTheDocs, PyPI, README updates

## Test plan

- [x] Roadmap files follow project templates
- [x] All three documents created in `.roadmap/planning/method-should-be-property/`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)