### PR TITLE
feat(stringly-typed): Add Python equality chain detection (PR3)

### DIFF
--- a/.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md
+++ b/.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md
@@ -46,8 +46,8 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the stringly-t
 4. **Update this document** after completing each PR
 
 ## Current Status
-**Current PR**: PR3 - Python Pattern 2 - Equality Chains (Not Started)
-**Infrastructure State**: Module structure, config, and membership validation detection complete
+**Current PR**: PR4 - TypeScript Single-File Detection (Not Started)
+**Infrastructure State**: Module structure, config, membership validation, and equality chain detection complete
 **Feature Target**: Detect stringly-typed code and suggest enum alternatives
 
 ## Required Documents Location
@@ -60,21 +60,35 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the stringly-t
 
 ## Next PR to Implement
 
-### START HERE: PR3 - Python Pattern 2 - Equality Chains
+### START HERE: PR4 - TypeScript Single-File Detection
 
 **Quick Summary**:
-Detect `if x == 'a' elif x == 'b'` patterns and match statements in Python.
+Detect stringly-typed patterns in TypeScript files using tree-sitter.
 
 **Pre-flight Checklist**:
-- [ ] Verify branch `feature/stringly-typed-pr3-equality-chains` is created
-- [ ] Review existing `src/linters/stringly_typed/python/` structure
+- [ ] Verify branch `feature/stringly-typed-pr4-typescript` is created
+- [ ] Review existing `src/linters/stringly_typed/python/` structure for reference
 - [ ] Review PR_BREAKDOWN.md for detailed implementation steps
+- [ ] Study tree-sitter usage in existing TypeScript analyzers
 
 **Prerequisites Complete**:
 - [x] PR1 complete - module structure and config ready
 - [x] PR2 complete - membership validation detection working
+- [x] PR3 complete - equality chain detection working
 - [x] StringlyTypedConfig dataclass with all fields
 - [x] Test fixtures and analyzer structure in place
+
+**Completed PR3 - Python Pattern 2 - Equality Chains**:
+- [x] Created `src/linters/stringly_typed/python/conditional_detector.py` with AST visitor
+- [x] Created `src/linters/stringly_typed/python/condition_extractor.py` for BoolOp extraction
+- [x] Created `src/linters/stringly_typed/python/match_analyzer.py` for match statements
+- [x] Created `src/linters/stringly_typed/python/constants.py` for shared constants
+- [x] EqualityChainPattern dataclass for structured pattern representation
+- [x] Updated analyzer.py to integrate ConditionalPatternDetector
+- [x] 20 new tests for conditional patterns (64 total in stringly_typed)
+- [x] All 883 project tests passing
+- [x] Pylint 10.00/10, Xenon A-grade
+- [x] All 9 quality checks passing
 
 **Completed PR2 - Python Pattern 1 - Membership Validation**:
 - [x] Created `src/linters/stringly_typed/python/__init__.py`
@@ -91,10 +105,10 @@ Detect `if x == 'a' elif x == 'b'` patterns and match statements in Python.
 ---
 
 ## Overall Progress
-**Total Completion**: 20% (2/10 PRs completed)
+**Total Completion**: 30% (3/10 PRs completed)
 
 ```
-[##........] 20% Complete
+[###.......] 30% Complete
 ```
 
 ---
@@ -105,7 +119,7 @@ Detect `if x == 'a' elif x == 'b'` patterns and match statements in Python.
 |----|-------|--------|------------|------------|----------|-------|
 | PR1 | Infrastructure & Test Framework | Complete | 100% | Low | P0 | Config dataclass + tests |
 | PR2 | Python Pattern 1 - Membership Validation | Complete | 100% | Medium | P0 | AST visitor + 29 tests |
-| PR3 | Python Pattern 2 - Equality Chains | Not Started | 0% | Medium | P1 | |
+| PR3 | Python Pattern 2 - Equality Chains | Complete | 100% | Medium | P1 | If/elif chains, match stmts + 20 tests |
 | PR4 | TypeScript Single-File Detection | Not Started | 0% | Medium | P1 | |
 | PR5 | Cross-File Storage & Detection | Not Started | 0% | High | P0 | |
 | PR6 | Function Call Tracking | Not Started | 0% | High | P1 | |

--- a/src/linters/stringly_typed/python/__init__.py
+++ b/src/linters/stringly_typed/python/__init__.py
@@ -4,13 +4,14 @@ Purpose: Python-specific detection for stringly-typed patterns
 Scope: Python AST analysis for membership validation and equality chain detection
 
 Overview: Exposes Python analysis components for detecting stringly-typed patterns in Python
-    source code. Includes validation_detector for finding 'x in ("a", "b")' patterns and
-    analyzer for coordinating detection across Python files. Uses AST traversal to identify
-    where plain strings are used instead of proper enums or typed alternatives.
+    source code. Includes validation_detector for finding 'x in ("a", "b")' patterns,
+    conditional_detector for finding if/elif chains and match statements, and analyzer
+    for coordinating detection across Python files. Uses AST traversal to identify where
+    plain strings are used instead of proper enums or typed alternatives.
 
 Dependencies: ast module for Python AST parsing
 
-Exports: MembershipValidationDetector, PythonStringlyTypedAnalyzer
+Exports: MembershipValidationDetector, ConditionalPatternDetector, PythonStringlyTypedAnalyzer
 
 Interfaces: Detector and analyzer classes for Python stringly-typed pattern detection
 
@@ -18,6 +19,11 @@ Implementation: AST NodeVisitor pattern for traversing Python syntax trees
 """
 
 from .analyzer import PythonStringlyTypedAnalyzer
+from .conditional_detector import ConditionalPatternDetector
 from .validation_detector import MembershipValidationDetector
 
-__all__ = ["MembershipValidationDetector", "PythonStringlyTypedAnalyzer"]
+__all__ = [
+    "ConditionalPatternDetector",
+    "MembershipValidationDetector",
+    "PythonStringlyTypedAnalyzer",
+]

--- a/src/linters/stringly_typed/python/condition_extractor.py
+++ b/src/linters/stringly_typed/python/condition_extractor.py
@@ -1,0 +1,131 @@
+"""
+Purpose: Extract string comparisons from Python condition expressions
+
+Scope: Parse BoolOp and Compare nodes to extract string equality patterns
+
+Overview: Provides functions to extract string comparisons from condition expressions
+    in Python AST. Handles simple comparisons, or-combined, and and-combined
+    conditions. Updates a collector object with extracted variable names and
+    string values. Separated from main detector to reduce complexity.
+
+Dependencies: ast module, variable_extractor
+
+Exports: extract_from_condition, is_simple_string_equality, get_string_constant
+
+Interfaces: Functions for extracting string comparisons from AST nodes
+
+Implementation: Recursive traversal of BoolOp nodes with Compare extraction
+"""
+
+import ast
+
+from .variable_extractor import extract_variable_name
+
+
+def extract_from_condition(
+    test: ast.expr,
+    collector: object,
+) -> None:
+    """Extract string comparisons from a condition expression.
+
+    Handles simple comparisons, or-combined, and and-combined comparisons.
+
+    Args:
+        test: The test expression from an if/elif
+        collector: Collector to accumulate results into (must have variable_name
+                  and string_values attributes)
+    """
+    if isinstance(test, ast.BoolOp):
+        _extract_from_bool_op(test, collector)
+    elif isinstance(test, ast.Compare):
+        _extract_from_compare(test, collector)
+
+
+def _extract_from_bool_op(node: ast.BoolOp, collector: object) -> None:
+    """Extract from BoolOp (And/Or combined comparisons).
+
+    Args:
+        node: BoolOp node
+        collector: Collector to accumulate results into
+    """
+    for value in node.values:
+        _handle_bool_op_value(value, collector)
+
+
+def _handle_bool_op_value(value: ast.expr, collector: object) -> None:
+    """Handle a single value from a BoolOp node.
+
+    Args:
+        value: Expression value from BoolOp
+        collector: Collector to accumulate results into
+    """
+    if isinstance(value, ast.Compare):
+        _extract_from_compare(value, collector)
+    elif isinstance(value, ast.BoolOp):
+        _extract_from_bool_op(value, collector)
+
+
+def _extract_from_compare(node: ast.Compare, collector: object) -> None:
+    """Extract string value from a Compare node with Eq/NotEq.
+
+    Args:
+        node: Compare node to analyze
+        collector: Collector to accumulate results into
+    """
+    if not _is_simple_equality(node):
+        return
+
+    string_value = _get_string_constant(node)
+    if string_value is None:
+        return
+
+    var_name = extract_variable_name(node.left)
+    _update_collector(collector, var_name, string_value)
+
+
+def _is_simple_equality(node: ast.Compare) -> bool:
+    """Check if Compare is a simple equality with one operator.
+
+    Args:
+        node: Compare node to check
+
+    Returns:
+        True if it's a simple x == y or x != y comparison
+    """
+    if len(node.ops) != 1:
+        return False
+    return isinstance(node.ops[0], (ast.Eq, ast.NotEq))
+
+
+def _get_string_constant(node: ast.Compare) -> str | None:
+    """Get string constant from the right side of comparison.
+
+    Args:
+        node: Compare node to extract from
+
+    Returns:
+        String value if comparator is a string constant, None otherwise
+    """
+    comparator = node.comparators[0]
+    if isinstance(comparator, ast.Constant) and isinstance(comparator.value, str):
+        return comparator.value
+    return None
+
+
+def _update_collector(
+    collector: object,
+    var_name: str | None,
+    string_value: str,
+) -> None:
+    """Update collector with extracted variable and value.
+
+    Args:
+        collector: Collector to update
+        var_name: Variable name from comparison
+        string_value: String value from comparison
+    """
+    if collector.variable_name is None:  # type: ignore[attr-defined]
+        collector.variable_name = var_name  # type: ignore[attr-defined]
+    # Only add if same variable (or no variable tracking)
+    if collector.variable_name == var_name or var_name is None:  # type: ignore[attr-defined]
+        collector.string_values.add(string_value)  # type: ignore[attr-defined]

--- a/src/linters/stringly_typed/python/conditional_detector.py
+++ b/src/linters/stringly_typed/python/conditional_detector.py
@@ -1,0 +1,176 @@
+"""
+Purpose: Detect equality chain patterns in Python AST
+
+Scope: Find 'if x == "a" elif x == "b"', or-combined, and match statement patterns
+
+Overview: Provides ConditionalPatternDetector class that traverses Python AST to find
+    equality chain patterns where strings are used instead of enums. Detects single
+    equality comparisons with string constants, aggregates values from if/elif chains,
+    handles or-combined comparisons, and supports Python 3.10+ match statements.
+    Returns structured EqualityChainPattern dataclass instances with aggregated
+    string values, pattern type, location, and optional variable name.
+
+Dependencies: ast module for AST parsing, dataclasses for pattern structure,
+    condition_extractor for comparison extraction, match_analyzer for match statements
+
+Exports: ConditionalPatternDetector class, EqualityChainPattern dataclass
+
+Interfaces: ConditionalPatternDetector.find_patterns(tree) -> list[EqualityChainPattern]
+
+Implementation: AST NodeVisitor pattern with If node chain traversal and Match statement handling
+"""
+
+import ast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from .condition_extractor import extract_from_condition
+from .constants import MIN_VALUES_FOR_PATTERN
+from .match_analyzer import analyze_match_statement
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@dataclass
+class EqualityChainPattern:
+    """Represents a detected equality chain pattern.
+
+    Captures information about stringly-typed equality checks including aggregated
+    string values from chains, pattern type, source location, and variable name.
+    """
+
+    string_values: set[str]
+    """Set of string values aggregated from the equality chain."""
+
+    pattern_type: str
+    """Type of pattern: 'equality_chain', 'or_combined', or 'match_statement'."""
+
+    line_number: int
+    """Line number where the pattern starts (1-indexed)."""
+
+    column: int
+    """Column number where the pattern starts (0-indexed)."""
+
+    variable_name: str | None
+    """Variable name being compared, if identifiable from a simple expression."""
+
+
+@dataclass
+class _ChainCollector:
+    """Internal collector for aggregating values from if/elif chains."""
+
+    variable_name: str | None = None
+    string_values: set[str] = field(default_factory=set)
+    line_number: int = 0
+    column: int = 0
+
+
+class ConditionalPatternDetector(ast.NodeVisitor):
+    """Detects equality chain patterns in Python AST.
+
+    Finds patterns like 'if x == "a" elif x == "b"', or-combined comparisons,
+    and match statements where strings are used instead of proper enums.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the detector."""
+        self.patterns: list[EqualityChainPattern] = []
+        self._processed_if_nodes: set[int] = set()
+
+    def find_patterns(self, tree: ast.AST) -> list[EqualityChainPattern]:
+        """Find all equality chain patterns in the AST.
+
+        Args:
+            tree: The AST to analyze
+
+        Returns:
+            List of EqualityChainPattern instances for each detected pattern
+        """
+        self.patterns = []
+        self._processed_if_nodes = set()
+        self.visit(tree)
+        return self.patterns
+
+    def visit_If(self, node: ast.If) -> None:  # pylint: disable=invalid-name
+        """Visit an If node to check for equality chain patterns.
+
+        Args:
+            node: The If node to analyze
+        """
+        if id(node) not in self._processed_if_nodes:
+            self._analyze_if_chain(node)
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:  # pylint: disable=invalid-name
+        """Visit a Match node to check for string case patterns.
+
+        Args:
+            node: The Match node to analyze
+        """
+        pattern = analyze_match_statement(node, EqualityChainPattern)
+        if pattern is not None:
+            self.patterns.append(pattern)  # type: ignore[arg-type]
+        self.generic_visit(node)
+
+    def _analyze_if_chain(self, node: ast.If) -> None:
+        """Analyze an if/elif chain for equality patterns.
+
+        Args:
+            node: The starting If node of the chain
+        """
+        collector = _ChainCollector(line_number=node.lineno, column=node.col_offset)
+
+        for if_node in self._iter_if_chain(node):
+            self._processed_if_nodes.add(id(if_node))
+            extract_from_condition(if_node.test, collector)
+
+        self._emit_pattern_if_valid(collector)
+
+    def _iter_if_chain(self, node: ast.If) -> "Iterator[ast.If]":
+        """Iterate through an if/elif chain.
+
+        Args:
+            node: Starting If node
+
+        Yields:
+            Each If node in the chain including elif branches
+        """
+        yield node
+        current: ast.If | None = node
+
+        while current is not None:
+            current = self._get_next_elif(current)
+            if current is not None:
+                yield current
+
+    def _get_next_elif(self, node: ast.If) -> ast.If | None:
+        """Get the next elif node in a chain.
+
+        Args:
+            node: Current If node
+
+        Returns:
+            Next elif If node, or None if no elif exists
+        """
+        if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+            return node.orelse[0]
+        return None
+
+    def _emit_pattern_if_valid(self, collector: _ChainCollector) -> None:
+        """Emit a pattern if collector has sufficient values.
+
+        Args:
+            collector: Collector with aggregated values
+        """
+        if len(collector.string_values) < MIN_VALUES_FOR_PATTERN:
+            return
+
+        pattern = EqualityChainPattern(
+            string_values=collector.string_values,
+            pattern_type="equality_chain",
+            line_number=collector.line_number,
+            column=collector.column,
+            variable_name=collector.variable_name,
+        )
+        self.patterns.append(pattern)

--- a/src/linters/stringly_typed/python/constants.py
+++ b/src/linters/stringly_typed/python/constants.py
@@ -1,0 +1,21 @@
+"""
+Purpose: Shared constants for stringly-typed Python detection
+
+Scope: Common configuration values used across Python pattern detectors
+
+Overview: Provides shared constants used by MembershipValidationDetector,
+    ConditionalPatternDetector, and other Python detection components.
+    Centralizes configuration values to ensure consistency and avoid
+    duplication across detector implementations.
+
+Dependencies: None
+
+Exports: MIN_VALUES_FOR_PATTERN constant
+
+Interfaces: Constants only, no function interfaces
+
+Implementation: Simple module-level constant definitions
+"""
+
+# Minimum number of string values to consider as enum candidate
+MIN_VALUES_FOR_PATTERN = 2

--- a/src/linters/stringly_typed/python/match_analyzer.py
+++ b/src/linters/stringly_typed/python/match_analyzer.py
@@ -1,0 +1,88 @@
+"""
+Purpose: Analyze Python match statements for stringly-typed patterns
+
+Scope: Extract string values from match statement cases
+
+Overview: Provides MatchStatementAnalyzer class that analyzes Python 3.10+ match
+    statements to detect stringly-typed patterns. Extracts string values from
+    case patterns and returns structured results. Separated from main detector
+    to maintain single responsibility and reduce class complexity.
+
+Dependencies: ast module, constants module, variable_extractor
+
+Exports: MatchStatementAnalyzer class
+
+Interfaces: MatchStatementAnalyzer.analyze(node) -> EqualityChainPattern | None
+
+Implementation: AST pattern matching for MatchValue nodes with string constants
+"""
+
+import ast
+
+from .constants import MIN_VALUES_FOR_PATTERN
+from .variable_extractor import extract_variable_name
+
+
+def analyze_match_statement(
+    node: ast.Match,
+    pattern_class: type,
+) -> object | None:
+    """Analyze a match statement for string case patterns.
+
+    Args:
+        node: Match statement node to analyze
+        pattern_class: The EqualityChainPattern class to use for results
+
+    Returns:
+        Pattern instance if valid match found, None otherwise
+    """
+    string_values = _collect_string_cases(node.cases)
+
+    if len(string_values) < MIN_VALUES_FOR_PATTERN:
+        return None
+
+    var_name = extract_variable_name(node.subject)
+    return pattern_class(
+        string_values=string_values,
+        pattern_type="match_statement",
+        line_number=node.lineno,
+        column=node.col_offset,
+        variable_name=var_name,
+    )
+
+
+def _collect_string_cases(cases: list[ast.match_case]) -> set[str]:
+    """Collect string values from match cases.
+
+    Args:
+        cases: List of match_case nodes
+
+    Returns:
+        Set of string values from MatchValue patterns
+    """
+    string_values: set[str] = set()
+
+    for case in cases:
+        value = _extract_case_string_value(case.pattern)
+        if value is not None:
+            string_values.add(value)
+
+    return string_values
+
+
+def _extract_case_string_value(pattern: ast.pattern) -> str | None:
+    """Extract string value from a case pattern.
+
+    Args:
+        pattern: Match case pattern node
+
+    Returns:
+        String value if pattern is a MatchValue with string, None otherwise
+    """
+    if not isinstance(pattern, ast.MatchValue):
+        return None
+    if not isinstance(pattern.value, ast.Constant):
+        return None
+    if not isinstance(pattern.value.value, str):
+        return None
+    return pattern.value.value

--- a/src/linters/stringly_typed/python/validation_detector.py
+++ b/src/linters/stringly_typed/python/validation_detector.py
@@ -23,10 +23,8 @@ Implementation: AST NodeVisitor pattern with Compare node handling for In/NotIn 
 import ast
 from dataclasses import dataclass
 
+from .constants import MIN_VALUES_FOR_PATTERN
 from .variable_extractor import extract_variable_name
-
-# Minimum number of string values to consider as enum candidate
-MIN_VALUES_FOR_PATTERN = 2
 
 
 @dataclass

--- a/tests/unit/linters/stringly_typed/test_python_conditional_patterns.py
+++ b/tests/unit/linters/stringly_typed/test_python_conditional_patterns.py
@@ -1,0 +1,411 @@
+"""
+Purpose: Tests for Python equality chain pattern detection
+
+Scope: Unit tests for detecting 'if x == "a" elif x == "b"', or-combined, and match patterns
+
+Overview: Comprehensive test suite for ConditionalPatternDetector verifying correct
+    detection of equality chain patterns in Python AST. Tests cover single comparisons,
+    elif chains with value aggregation, or-combined comparisons, Python 3.10+ match
+    statements, and edge cases like non-string comparisons and mixed patterns.
+    Uses TDD approach - tests define expected behavior.
+
+Dependencies: pytest, ast module
+
+Exports: Test functions for conditional detector
+
+Interfaces: pytest test discovery
+
+Implementation: pytest fixtures with sample code, organized test classes by pattern type
+"""
+
+import ast
+
+from src.linters.stringly_typed.python.conditional_detector import (
+    ConditionalPatternDetector,
+    EqualityChainPattern,
+)
+
+
+class TestEqualityChainDetectorBasic:
+    """Tests for basic equality chain pattern detection."""
+
+    def test_detects_if_elif_chain_with_two_values(self) -> None:
+        """Detect if/elif chain with two string values."""
+        code = """
+def handle_status(status: str) -> None:
+    if status == "success":
+        print("Success!")
+    elif status == "failure":
+        print("Failed!")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        pattern = patterns[0]
+        assert pattern.string_values == {"success", "failure"}
+        assert pattern.pattern_type == "equality_chain"
+        assert pattern.variable_name == "status"
+
+    def test_detects_if_elif_chain_with_three_values(self) -> None:
+        """Detect if/elif chain with three string values."""
+        code = """
+def handle_status(status: str) -> None:
+    if status == "success":
+        print("Completed successfully")
+    elif status == "failure":
+        print("Operation failed")
+    elif status == "pending":
+        print("Still waiting...")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        pattern = patterns[0]
+        assert pattern.string_values == {"success", "failure", "pending"}
+        assert pattern.variable_name == "status"
+
+    def test_ignores_single_comparison_without_elif(self) -> None:
+        """Ignore single string comparison without elif chain."""
+        code = """
+def check_status(status: str) -> bool:
+    if status == "success":
+        return True
+    return False
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Single comparison doesn't form a chain
+        assert len(patterns) == 0
+
+
+class TestOrCombinedPatterns:
+    """Tests for or-combined comparison detection."""
+
+    def test_detects_or_combined_comparisons(self) -> None:
+        """Detect x == 'a' or x == 'b' pattern."""
+        code = """
+def is_valid(mode: str) -> bool:
+    if mode == "debug" or mode == "release":
+        return True
+    return False
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"debug", "release"}
+        assert patterns[0].variable_name == "mode"
+
+    def test_detects_three_or_combined_comparisons(self) -> None:
+        """Detect three or-combined comparisons."""
+        code = """
+def is_primary_color(color: str) -> bool:
+    if color == "red" or color == "blue" or color == "yellow":
+        return True
+    return False
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"red", "blue", "yellow"}
+
+
+class TestMatchStatementPatterns:
+    """Tests for Python 3.10+ match statement detection."""
+
+    def test_detects_match_statement_with_string_cases(self) -> None:
+        """Detect match statement with string literal cases."""
+        code = """
+def handle_mode(mode: str) -> None:
+    match mode:
+        case "debug":
+            print("Debug mode")
+        case "release":
+            print("Release mode")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        pattern = patterns[0]
+        assert pattern.string_values == {"debug", "release"}
+        assert pattern.pattern_type == "match_statement"
+        assert pattern.variable_name == "mode"
+
+    def test_detects_match_with_multiple_cases(self) -> None:
+        """Detect match statement with multiple string cases."""
+        code = """
+def handle_status(status: str) -> int:
+    match status:
+        case "pending":
+            return 0
+        case "running":
+            return 1
+        case "completed":
+            return 2
+        case "failed":
+            return 3
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"pending", "running", "completed", "failed"}
+
+    def test_ignores_match_with_wildcard_only(self) -> None:
+        """Ignore match statement with only wildcard pattern."""
+        code = """
+def handle_any(value: str) -> None:
+    match value:
+        case _:
+            print("Catch-all")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 0
+
+    def test_ignores_match_with_single_string_case(self) -> None:
+        """Ignore match statement with only one string case."""
+        code = """
+def handle_special(value: str) -> None:
+    match value:
+        case "special":
+            print("Special case")
+        case _:
+            print("Other")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Single string case doesn't form an enum candidate
+        assert len(patterns) == 0
+
+
+class TestEdgeCases:
+    """Tests for edge cases and false positive prevention."""
+
+    def test_ignores_non_string_comparisons(self) -> None:
+        """Ignore comparisons with non-string values."""
+        code = """
+def check_code(code: int) -> None:
+    if code == 200:
+        print("OK")
+    elif code == 404:
+        print("Not found")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 0
+
+    def test_ignores_variable_comparisons(self) -> None:
+        """Ignore comparisons against variables (not literals)."""
+        code = """
+SUCCESS = "success"
+FAILURE = "failure"
+def check(status: str) -> None:
+    if status == SUCCESS:
+        print("OK")
+    elif status == FAILURE:
+        print("Failed")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Comparisons against variables don't count as string literals
+        assert len(patterns) == 0
+
+    def test_captures_attribute_access_as_variable(self) -> None:
+        """Capture attribute access (e.g., self.status) as variable name."""
+        code = """
+class Handler:
+    def handle(self) -> None:
+        if self.status == "active":
+            self.process()
+        elif self.status == "inactive":
+            self.skip()
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"active", "inactive"}
+        assert "status" in patterns[0].variable_name
+
+    def test_detects_multiple_chains_in_same_function(self) -> None:
+        """Detect multiple independent if/elif chains."""
+        code = """
+def validate_all(status: str, mode: str) -> bool:
+    if status == "active":
+        print("Active")
+    elif status == "inactive":
+        print("Inactive")
+
+    if mode == "debug":
+        return False
+    elif mode == "release":
+        return True
+    return False
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 2
+        string_sets = {frozenset(p.string_values) for p in patterns}
+        assert frozenset({"active", "inactive"}) in string_sets
+        assert frozenset({"debug", "release"}) in string_sets
+
+    def test_ignores_mixed_and_or_conditions(self) -> None:
+        """Handle mixed AND/OR conditions correctly."""
+        code = """
+def complex_check(status: str, active: bool) -> None:
+    if status == "ready" and active:
+        print("Go!")
+    elif status == "waiting":
+        print("Wait...")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Should detect the chain even with mixed conditions
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"ready", "waiting"}
+
+    def test_handles_nested_if_statements(self) -> None:
+        """Handle nested if statements correctly (don't double-count)."""
+        code = """
+def nested_check(outer: str, inner: str) -> None:
+    if outer == "first":
+        if inner == "a":
+            print("1a")
+        elif inner == "b":
+            print("1b")
+    elif outer == "second":
+        print("2")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Should detect both chains independently
+        assert len(patterns) == 2
+
+
+class TestEqualityChainPatternDataclass:
+    """Tests for EqualityChainPattern dataclass."""
+
+    def test_pattern_has_required_fields(self) -> None:
+        """Verify EqualityChainPattern has all required fields."""
+        pattern = EqualityChainPattern(
+            string_values={"a", "b"},
+            pattern_type="equality_chain",
+            line_number=10,
+            column=4,
+            variable_name="status",
+        )
+
+        assert pattern.string_values == {"a", "b"}
+        assert pattern.pattern_type == "equality_chain"
+        assert pattern.line_number == 10
+        assert pattern.column == 4
+        assert pattern.variable_name == "status"
+
+    def test_pattern_variable_name_optional(self) -> None:
+        """Verify variable_name is optional."""
+        pattern = EqualityChainPattern(
+            string_values={"a", "b"},
+            pattern_type="match_statement",
+            line_number=10,
+            column=4,
+            variable_name=None,
+        )
+
+        assert pattern.variable_name is None
+
+
+class TestRealWorldScenarios:
+    """Tests for real-world code patterns."""
+
+    def test_http_status_handling(self) -> None:
+        """Detect stringly-typed HTTP status handling."""
+        code = """
+def handle_response(status: str) -> None:
+    if status == "ok":
+        process_success()
+    elif status == "error":
+        handle_error()
+    elif status == "timeout":
+        retry()
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"ok", "error", "timeout"}
+
+    def test_environment_switching(self) -> None:
+        """Detect stringly-typed environment switching."""
+        code = """
+def get_config(env: str) -> dict:
+    if env == "development":
+        return DEV_CONFIG
+    elif env == "staging":
+        return STAGING_CONFIG
+    elif env == "production":
+        return PROD_CONFIG
+    else:
+        raise ValueError(f"Unknown env: {env}")
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        assert len(patterns) == 1
+        assert patterns[0].string_values == {"development", "staging", "production"}
+
+    def test_state_machine_pattern(self) -> None:
+        """Detect stringly-typed state machine pattern."""
+        code = """
+def transition(state: str, event: str) -> str:
+    match state:
+        case "idle":
+            if event == "start":
+                return "running"
+        case "running":
+            if event == "pause":
+                return "paused"
+            elif event == "stop":
+                return "idle"
+        case "paused":
+            if event == "resume":
+                return "running"
+    return state
+"""
+        tree = ast.parse(code)
+        detector = ConditionalPatternDetector()
+        patterns = detector.find_patterns(tree)
+
+        # Should detect match statement pattern
+        assert any(p.pattern_type == "match_statement" for p in patterns)
+        state_pattern = next(p for p in patterns if p.pattern_type == "match_statement")
+        assert state_pattern.string_values == {"idle", "running", "paused"}


### PR DESCRIPTION
## Summary

- Add `conditional_detector.py` with AST visitor for detecting if/elif equality chains
- Add `condition_extractor.py` for extracting comparisons from BoolOp (and/or) nodes
- Add `match_analyzer.py` for Python 3.10+ match statement detection
- Add `constants.py` for shared `MIN_VALUES_FOR_PATTERN` constant (DRY compliance)
- Update `analyzer.py` to integrate `ConditionalPatternDetector`
- Update `validation_detector.py` to use shared constants module
- Add 20 comprehensive tests covering all conditional pattern scenarios
- Update `PROGRESS_TRACKER.md` to reflect 30% completion (3/10 PRs)

## Patterns Detected

| Pattern | Example | Detection |
|---------|---------|-----------|
| If/elif chains | `if x == "a" elif x == "b"` | Aggregates string values across chain |
| Or-combined | `if x == "a" or x == "b"` | Extracts from BoolOp nodes |
| Match statements | `match x: case "a": ... case "b": ...` | Python 3.10+ support |
| Mixed conditions | `if x == "a" and active elif x == "b"` | Handles and/or combinations |

## Files Changed

### New Files
- `src/linters/stringly_typed/python/conditional_detector.py` - Main detector class
- `src/linters/stringly_typed/python/condition_extractor.py` - BoolOp extraction helper
- `src/linters/stringly_typed/python/match_analyzer.py` - Match statement helper
- `src/linters/stringly_typed/python/constants.py` - Shared constants
- `tests/unit/linters/stringly_typed/test_python_conditional_patterns.py` - 20 tests

### Modified Files
- `src/linters/stringly_typed/python/__init__.py` - Added new exports
- `src/linters/stringly_typed/python/analyzer.py` - Integrated new detector
- `src/linters/stringly_typed/python/validation_detector.py` - Use shared constants
- `.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md` - Updated progress

## Test Plan

- [x] All 20 new conditional pattern tests pass
- [x] All 883 project tests pass
- [x] `just lint-full` passes (Pylint 10.00/10, Xenon A-grade)
- [x] All 9 quality checks pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)