### PR TITLE
feat(stringly-typed): Add cross-file storage and detection (PR5)

### DIFF
--- a/.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md
+++ b/.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md
@@ -46,8 +46,8 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the stringly-t
 4. **Update this document** after completing each PR
 
 ## Current Status
-**Current PR**: PR4 - TypeScript Single-File Detection (Not Started)
-**Infrastructure State**: Module structure, config, membership validation, and equality chain detection complete
+**Current PR**: PR6 - Function Call Tracking (Not Started)
+**Infrastructure State**: Module structure, config, Python/TypeScript detection, and cross-file storage complete
 **Feature Target**: Detect stringly-typed code and suggest enum alternatives
 
 ## Required Documents Location
@@ -60,23 +60,43 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the stringly-t
 
 ## Next PR to Implement
 
-### START HERE: PR4 - TypeScript Single-File Detection
+### START HERE: PR6 - Function Call Tracking
 
 **Quick Summary**:
-Detect stringly-typed patterns in TypeScript files using tree-sitter.
+Track function/method calls that consistently receive the same string arguments, suggesting enum usage for those parameters.
 
 **Pre-flight Checklist**:
-- [ ] Verify branch `feature/stringly-typed-pr4-typescript` is created
-- [ ] Review existing `src/linters/stringly_typed/python/` structure for reference
+- [ ] Verify branch `feature/stringly-typed-pr6-function-calls` is created
+- [ ] Review existing analyzers for function call detection patterns
 - [ ] Review PR_BREAKDOWN.md for detailed implementation steps
-- [ ] Study tree-sitter usage in existing TypeScript analyzers
+- [ ] Analyze how to track parameter positions and values
 
 **Prerequisites Complete**:
-- [x] PR1 complete - module structure and config ready
-- [x] PR2 complete - membership validation detection working
-- [x] PR3 complete - equality chain detection working
-- [x] StringlyTypedConfig dataclass with all fields
-- [x] Test fixtures and analyzer structure in place
+- [x] PR1-PR5 complete - full infrastructure and cross-file detection ready
+- [x] SQLite storage for cross-file pattern aggregation
+- [x] Violation generator with cross-file references
+- [x] Python and TypeScript single-file analyzers
+
+**Completed PR5 - Cross-File Storage & Detection**:
+- [x] Created `src/linters/stringly_typed/storage.py` with SQLite wrapper
+- [x] Created `src/linters/stringly_typed/storage_initializer.py` for factory pattern
+- [x] Created `src/linters/stringly_typed/violation_generator.py` for violation generation
+- [x] Created `src/linters/stringly_typed/ignore_utils.py` for shared utilities
+- [x] Updated `src/linters/stringly_typed/linter.py` with StringlyTypedRule
+- [x] Implemented two-phase pattern: check() stores data, finalize() generates violations
+- [x] Cross-file duplicate detection via SQLite hash queries
+- [x] Violation messages with cross-file references
+- [x] 24 unit tests for storage, 17 integration tests for cross-file detection
+- [x] All 924 project tests passing
+- [x] Pylint 10.00/10, Xenon A-grade
+- [x] All 9 quality checks passing
+
+**Completed PR4 - TypeScript Single-File Detection**:
+- [x] Created `src/linters/stringly_typed/typescript/` analyzer structure
+- [x] Tree-sitter based pattern detection for TypeScript
+- [x] Membership validation and equality chain patterns
+- [x] Integration with existing analyzer framework
+- [x] All quality checks passing
 
 **Completed PR3 - Python Pattern 2 - Equality Chains**:
 - [x] Created `src/linters/stringly_typed/python/conditional_detector.py` with AST visitor
@@ -105,10 +125,10 @@ Detect stringly-typed patterns in TypeScript files using tree-sitter.
 ---
 
 ## Overall Progress
-**Total Completion**: 30% (3/10 PRs completed)
+**Total Completion**: 50% (5/10 PRs completed)
 
 ```
-[###.......] 30% Complete
+[#####.....] 50% Complete
 ```
 
 ---
@@ -120,8 +140,8 @@ Detect stringly-typed patterns in TypeScript files using tree-sitter.
 | PR1 | Infrastructure & Test Framework | Complete | 100% | Low | P0 | Config dataclass + tests |
 | PR2 | Python Pattern 1 - Membership Validation | Complete | 100% | Medium | P0 | AST visitor + 29 tests |
 | PR3 | Python Pattern 2 - Equality Chains | Complete | 100% | Medium | P1 | If/elif chains, match stmts + 20 tests |
-| PR4 | TypeScript Single-File Detection | Not Started | 0% | Medium | P1 | |
-| PR5 | Cross-File Storage & Detection | Not Started | 0% | High | P0 | |
+| PR4 | TypeScript Single-File Detection | Complete | 100% | Medium | P1 | Tree-sitter analyzer |
+| PR5 | Cross-File Storage & Detection | Complete | 100% | High | P0 | SQLite storage + finalize() hook + 41 tests |
 | PR6 | Function Call Tracking | Not Started | 0% | High | P1 | |
 | PR7 | CLI Integration & Output Formats | Not Started | 0% | Medium | P0 | |
 | PR8 | False Positive Filtering | Not Started | 0% | Medium | P1 | |

--- a/src/linters/stringly_typed/__init__.py
+++ b/src/linters/stringly_typed/__init__.py
@@ -4,20 +4,29 @@ Purpose: Stringly-typed linter package exports
 Scope: Public API for stringly-typed linter module
 
 Overview: Provides the public interface for the stringly-typed linter package. Exports
-    StringlyTypedConfig for configuration of the linter. The stringly-typed linter detects
-    code patterns where plain strings are used instead of proper enums or typed alternatives,
-    helping identify potential type safety improvements. This module serves as the entry
-    point for users of the stringly-typed linter.
+    StringlyTypedConfig for configuration and StringlyTypedRule for linting. The stringly-typed
+    linter detects code patterns where plain strings are used instead of proper enums or typed
+    alternatives, helping identify potential type safety improvements. Supports cross-file
+    detection to find repeated string patterns across the codebase.
 
-Dependencies: .config for StringlyTypedConfig
+Dependencies: .config for StringlyTypedConfig, .linter for StringlyTypedRule,
+    .storage for StringlyTypedStorage
 
-Exports: StringlyTypedConfig dataclass
+Exports: StringlyTypedConfig, StringlyTypedRule, StringlyTypedStorage, StoredPattern
 
-Interfaces: Configuration loading via StringlyTypedConfig.from_dict()
+Interfaces: Configuration loading via StringlyTypedConfig.from_dict(),
+    StringlyTypedRule.check() and finalize() for linting
 
 Implementation: Module-level exports with __all__ definition
 """
 
 from src.linters.stringly_typed.config import StringlyTypedConfig
+from src.linters.stringly_typed.linter import StringlyTypedRule
+from src.linters.stringly_typed.storage import StoredPattern, StringlyTypedStorage
 
-__all__ = ["StringlyTypedConfig"]
+__all__ = [
+    "StringlyTypedConfig",
+    "StringlyTypedRule",
+    "StringlyTypedStorage",
+    "StoredPattern",
+]

--- a/src/linters/stringly_typed/ignore_utils.py
+++ b/src/linters/stringly_typed/ignore_utils.py
@@ -1,0 +1,36 @@
+"""
+Purpose: Shared ignore pattern matching utilities
+
+Scope: Common ignore pattern checking for stringly-typed linter components
+
+Overview: Provides shared utility functions for checking if file paths match ignore patterns.
+    Used by both the main linter and violation generator to avoid duplicating ignore pattern
+    matching logic. Centralizes the ignore pattern matching algorithm.
+
+Dependencies: pathlib.Path
+
+Exports: is_ignored function
+
+Interfaces: is_ignored(file_path, ignore_patterns) -> bool
+
+Implementation: Simple substring matching for ignore patterns
+"""
+
+from pathlib import Path
+
+
+def is_ignored(file_path: str | Path, ignore_patterns: list[str]) -> bool:
+    """Check if file path matches any ignore pattern.
+
+    Args:
+        file_path: Path to check (string or Path object)
+        ignore_patterns: List of patterns to match against
+
+    Returns:
+        True if file should be ignored
+    """
+    if not ignore_patterns:
+        return False
+
+    path_str = str(file_path)
+    return any(pattern in path_str for pattern in ignore_patterns)

--- a/src/linters/stringly_typed/linter.py
+++ b/src/linters/stringly_typed/linter.py
@@ -1,0 +1,223 @@
+"""
+Purpose: Main stringly-typed linter rule with cross-file detection
+
+Scope: StringlyTypedRule implementing MultiLanguageLintRule for cross-file pattern detection
+
+Overview: Implements stringly-typed linter rule following MultiLanguageLintRule interface with
+    cross-file detection using SQLite storage. Orchestrates pattern detection by delegating to
+    language-specific analyzers (Python, TypeScript). During check() phase, patterns are collected
+    into storage. During finalize() phase, storage is queried for patterns appearing across
+    multiple files and violations are generated. Maintains minimal orchestration logic to comply
+    with SRP.
+
+Dependencies: MultiLanguageLintRule, BaseLintContext, PythonStringlyTypedAnalyzer,
+    StringlyTypedStorage, StorageInitializer, ViolationGenerator, StringlyTypedConfig
+
+Exports: StringlyTypedRule class
+
+Interfaces: StringlyTypedRule.check(context) -> list[Violation],
+    StringlyTypedRule.finalize() -> list[Violation]
+
+Implementation: Two-phase pattern: check() stores data, finalize() generates violations.
+    Delegates all logic to helper classes, maintains only orchestration and state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.core.base import BaseLintContext, MultiLanguageLintRule
+from src.core.linter_utils import load_linter_config
+from src.core.types import Violation
+
+from .config import StringlyTypedConfig
+from .ignore_utils import is_ignored
+from .python.analyzer import AnalysisResult, PythonStringlyTypedAnalyzer
+from .storage import StoredPattern, StringlyTypedStorage
+from .storage_initializer import StorageInitializer
+from .violation_generator import ViolationGenerator
+
+
+def compute_string_set_hash(values: set[str]) -> int:
+    """Compute consistent hash for a set of strings.
+
+    Args:
+        values: Set of string values to hash
+
+    Returns:
+        Hash value based on sorted, lowercased strings
+    """
+    return hash(tuple(sorted(s.lower() for s in values)))
+
+
+def _is_ready_for_analysis(context: BaseLintContext, storage: StringlyTypedStorage | None) -> bool:
+    """Check if context and storage are ready for analysis."""
+    return bool(context.file_path and context.file_content and storage)
+
+
+def _convert_to_stored_pattern(result: AnalysisResult) -> StoredPattern:
+    """Convert AnalysisResult to StoredPattern.
+
+    Args:
+        result: Analysis result from language analyzer
+
+    Returns:
+        StoredPattern for storage
+    """
+    return StoredPattern(
+        file_path=result.file_path,
+        line_number=result.line_number,
+        column=result.column,
+        variable_name=result.variable_name,
+        string_set_hash=compute_string_set_hash(result.string_values),
+        string_values=sorted(result.string_values),
+        pattern_type=result.pattern_type,
+        details=result.details,
+    )
+
+
+@dataclass
+class StringlyTypedComponents:
+    """Component dependencies for stringly-typed linter."""
+
+    storage_initializer: StorageInitializer
+    violation_generator: ViolationGenerator
+    python_analyzer: PythonStringlyTypedAnalyzer
+
+
+class StringlyTypedRule(MultiLanguageLintRule):
+    """Detects stringly-typed patterns across project files.
+
+    Uses two-phase pattern:
+    1. check() - Collects patterns into SQLite storage (returns empty list)
+    2. finalize() - Queries storage and generates violations for cross-file patterns
+    """
+
+    def __init__(self) -> None:
+        """Initialize the stringly-typed rule with helper components."""
+        self._storage: StringlyTypedStorage | None = None
+        self._initialized = False
+        self._config: StringlyTypedConfig | None = None
+
+        # Helper components grouped to reduce instance attributes
+        self._helpers = StringlyTypedComponents(
+            storage_initializer=StorageInitializer(),
+            violation_generator=ViolationGenerator(),
+            python_analyzer=PythonStringlyTypedAnalyzer(),
+        )
+
+    @property
+    def rule_id(self) -> str:
+        """Unique identifier for this rule."""
+        return "stringly-typed.repeated-validation"
+
+    @property
+    def rule_name(self) -> str:
+        """Human-readable name for this rule."""
+        return "Stringly-Typed Pattern"
+
+    @property
+    def description(self) -> str:
+        """Description of what this rule checks."""
+        return "Detects stringly-typed code patterns that should use enums"
+
+    def _load_config(self, context: BaseLintContext) -> StringlyTypedConfig:
+        """Load configuration from context.
+
+        Args:
+            context: Lint context with metadata
+
+        Returns:
+            StringlyTypedConfig instance
+        """
+        return load_linter_config(context, "stringly_typed", StringlyTypedConfig)
+
+    def _check_python(
+        self, context: BaseLintContext, config: StringlyTypedConfig
+    ) -> list[Violation]:
+        """Analyze Python code and store patterns.
+
+        Args:
+            context: Lint context with file content
+            config: Stringly-typed configuration
+
+        Returns:
+            Empty list (violations generated in finalize)
+        """
+        self._ensure_storage_initialized(context, config)
+        self._analyze_python_file(context, config)
+        return []
+
+    def _check_typescript(
+        self, context: BaseLintContext, config: StringlyTypedConfig
+    ) -> list[Violation]:
+        """Analyze TypeScript code and store patterns.
+
+        Args:
+            context: Lint context with file content
+            config: Stringly-typed configuration
+
+        Returns:
+            Empty list (violations generated in finalize)
+
+        Note:
+            TypeScript analyzer integration is pending PR4 merge.
+        """
+        self._ensure_storage_initialized(context, config)
+        # TypeScript analyzer will be integrated when PR4 is merged
+        return []
+
+    def _ensure_storage_initialized(
+        self, context: BaseLintContext, config: StringlyTypedConfig
+    ) -> None:
+        """Initialize storage and analyzers on first call.
+
+        Args:
+            context: Lint context
+            config: Stringly-typed configuration
+        """
+        if not self._initialized:
+            self._storage = self._helpers.storage_initializer.initialize(context, config)
+            self._config = config
+            self._initialized = True
+
+    def _analyze_python_file(self, context: BaseLintContext, config: StringlyTypedConfig) -> None:
+        """Analyze Python file and store patterns.
+
+        Args:
+            context: Lint context with file content
+            config: Stringly-typed configuration
+        """
+        if not _is_ready_for_analysis(context, self._storage):
+            return
+
+        file_path = Path(context.file_path)  # type: ignore[arg-type]
+        if is_ignored(file_path, config.ignore):
+            return
+
+        self._helpers.python_analyzer.config = config
+        results = self._helpers.python_analyzer.analyze(context.file_content or "", file_path)
+        self._storage.add_patterns([_convert_to_stored_pattern(r) for r in results])  # type: ignore[union-attr]
+
+    def finalize(self) -> list[Violation]:
+        """Generate violations after all files processed.
+
+        Returns:
+            List of violations for patterns appearing in multiple files
+        """
+        if not self._storage or not self._config:
+            return []
+
+        # Generate violations from cross-file patterns
+        violations = self._helpers.violation_generator.generate_violations(
+            self._storage, self.rule_id, self._config
+        )
+
+        # Cleanup and reset state for next run
+        self._storage.close()
+        self._storage = None
+        self._config = None
+        self._initialized = False
+
+        return violations

--- a/src/linters/stringly_typed/storage.py
+++ b/src/linters/stringly_typed/storage.py
@@ -1,0 +1,254 @@
+"""
+Purpose: SQLite storage manager for stringly-typed pattern detection
+
+Scope: String validation pattern storage and cross-file duplicate detection queries
+
+Overview: Implements in-memory or temporary-file SQLite storage for stringly-typed pattern
+    detection. Stores string validation patterns with hash values computed from the string
+    values, enabling cross-file duplicate detection during a single linter run. Supports both
+    :memory: mode (fast, RAM-only) and tempfile mode (disk-backed for large projects). No
+    persistence between runs - storage is cleared when linter completes. Includes indexes
+    for fast hash lookups enabling efficient cross-file detection.
+
+Dependencies: Python sqlite3 module (stdlib), tempfile module (stdlib), pathlib.Path,
+    dataclasses, json module (stdlib)
+
+Exports: StoredPattern dataclass, StringlyTypedStorage class
+
+Interfaces: StringlyTypedStorage.__init__(storage_mode), add_pattern(pattern),
+    add_patterns(patterns), get_duplicate_hashes(min_files), get_patterns_by_hash(hash_value),
+    clear(), close()
+
+Implementation: SQLite with string_validations table, indexed on string_set_hash for
+    performance, storage_mode determines :memory: vs tempfile location
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# Row index constants for SQLite query results
+_COL_FILE_PATH = 0
+_COL_LINE_NUMBER = 1
+_COL_COLUMN = 2
+_COL_VARIABLE_NAME = 3
+_COL_STRING_SET_HASH = 4
+_COL_STRING_VALUES = 5
+_COL_PATTERN_TYPE = 6
+_COL_DETAILS = 7
+
+# Schema SQL for table creation
+_CREATE_TABLE_SQL = """CREATE TABLE IF NOT EXISTS string_validations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_path TEXT NOT NULL,
+    line_number INTEGER NOT NULL,
+    column_number INTEGER NOT NULL,
+    variable_name TEXT,
+    string_set_hash INTEGER NOT NULL,
+    string_values TEXT NOT NULL,
+    pattern_type TEXT NOT NULL,
+    details TEXT NOT NULL,
+    UNIQUE(file_path, line_number, column_number)
+)"""
+
+_CREATE_HASH_INDEX_SQL = (
+    "CREATE INDEX IF NOT EXISTS idx_string_hash ON string_validations(string_set_hash)"
+)
+
+_CREATE_FILE_INDEX_SQL = "CREATE INDEX IF NOT EXISTS idx_file_path ON string_validations(file_path)"
+
+
+def _row_to_pattern(row: tuple) -> StoredPattern:
+    """Convert a database row tuple to StoredPattern.
+
+    Args:
+        row: Tuple from SQLite query result
+
+    Returns:
+        StoredPattern instance
+    """
+    return StoredPattern(
+        file_path=Path(row[_COL_FILE_PATH]),
+        line_number=row[_COL_LINE_NUMBER],
+        column=row[_COL_COLUMN],
+        variable_name=row[_COL_VARIABLE_NAME],
+        string_set_hash=row[_COL_STRING_SET_HASH],
+        string_values=json.loads(row[_COL_STRING_VALUES]),
+        pattern_type=row[_COL_PATTERN_TYPE],
+        details=row[_COL_DETAILS],
+    )
+
+
+# pylint: disable=too-many-instance-attributes
+# Justification: StoredPattern is a pure data transfer object for SQLite storage.
+# All 8 fields are necessary: file location (3), variable info (1), hash/values (3), pattern type (1).
+@dataclass
+class StoredPattern:
+    """Represents a stringly-typed pattern stored in SQLite.
+
+    Captures all information needed to detect cross-file duplicates and generate
+    violations with meaningful context.
+    """
+
+    file_path: Path
+    """Path to the file containing the pattern."""
+
+    line_number: int
+    """Line number where the pattern occurs (1-indexed)."""
+
+    column: int
+    """Column number where the pattern starts (0-indexed)."""
+
+    variable_name: str | None
+    """Variable name involved in the pattern, if identifiable."""
+
+    string_set_hash: int
+    """Hash of the normalized string values for cross-file matching."""
+
+    string_values: list[str]
+    """Sorted list of string values in the pattern."""
+
+    pattern_type: str
+    """Type of pattern: membership_validation, equality_chain, etc."""
+
+    details: str
+    """Human-readable description of the detected pattern."""
+
+
+class StringlyTypedStorage:
+    """SQLite-backed storage for stringly-typed pattern detection.
+
+    Stores patterns from analyzed files and provides queries to find patterns
+    that appear across multiple files, enabling cross-file duplicate detection.
+    """
+
+    def __init__(self, storage_mode: str = "memory") -> None:
+        """Initialize storage with SQLite database.
+
+        Args:
+            storage_mode: Storage mode - "memory" (default) or "tempfile"
+        """
+        self._storage_mode = storage_mode
+        self._tempfile = None
+
+        # Create SQLite connection based on storage mode
+        if storage_mode == "memory":
+            self._db = sqlite3.connect(":memory:")
+        elif storage_mode == "tempfile":
+            # pylint: disable=consider-using-with
+            # Justification: tempfile must remain open for SQLite connection lifetime.
+            # It is explicitly closed in close() method when storage is finalized.
+            self._tempfile = tempfile.NamedTemporaryFile(suffix=".db", delete=True)
+            self._db = sqlite3.connect(self._tempfile.name)
+        else:
+            raise ValueError(f"Invalid storage_mode: {storage_mode}")
+
+        # Create schema inline
+        self._db.execute(_CREATE_TABLE_SQL)
+        self._db.execute(_CREATE_HASH_INDEX_SQL)
+        self._db.execute(_CREATE_FILE_INDEX_SQL)
+        self._db.commit()
+
+    def add_pattern(self, pattern: StoredPattern) -> None:
+        """Add a single pattern to storage.
+
+        Args:
+            pattern: StoredPattern instance to store
+        """
+        self.add_patterns([pattern])
+
+    def add_patterns(self, patterns: list[StoredPattern]) -> None:
+        """Add multiple patterns to storage in a batch.
+
+        Args:
+            patterns: List of StoredPattern instances to store
+        """
+        if not patterns:
+            return
+
+        for pattern in patterns:
+            self._db.execute(
+                """INSERT OR REPLACE INTO string_validations
+                   (file_path, line_number, column_number, variable_name,
+                    string_set_hash, string_values, pattern_type, details)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    str(pattern.file_path),
+                    pattern.line_number,
+                    pattern.column,
+                    pattern.variable_name,
+                    pattern.string_set_hash,
+                    json.dumps(pattern.string_values),
+                    pattern.pattern_type,
+                    pattern.details,
+                ),
+            )
+
+        self._db.commit()
+
+    def get_duplicate_hashes(self, min_files: int = 2) -> list[int]:
+        """Get hash values that appear in min_files or more files.
+
+        Args:
+            min_files: Minimum number of distinct files (default: 2)
+
+        Returns:
+            List of hash values appearing in at least min_files files
+        """
+        cursor = self._db.execute(
+            """SELECT string_set_hash FROM string_validations
+               GROUP BY string_set_hash
+               HAVING COUNT(DISTINCT file_path) >= ?""",
+            (min_files,),
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+    def get_patterns_by_hash(self, hash_value: int) -> list[StoredPattern]:
+        """Get all patterns with the given hash value.
+
+        Args:
+            hash_value: Hash value to search for
+
+        Returns:
+            List of StoredPattern instances with this hash
+        """
+        cursor = self._db.execute(
+            """SELECT file_path, line_number, column_number, variable_name,
+                      string_set_hash, string_values, pattern_type, details
+               FROM string_validations
+               WHERE string_set_hash = ?
+               ORDER BY file_path, line_number""",
+            (hash_value,),
+        )
+
+        return [_row_to_pattern(row) for row in cursor.fetchall()]
+
+    def get_all_patterns(self) -> list[StoredPattern]:
+        """Get all stored patterns.
+
+        Returns:
+            List of all StoredPattern instances in storage
+        """
+        cursor = self._db.execute(
+            """SELECT file_path, line_number, column_number, variable_name,
+                      string_set_hash, string_values, pattern_type, details
+               FROM string_validations
+               ORDER BY file_path, line_number"""
+        )
+
+        return [_row_to_pattern(row) for row in cursor.fetchall()]
+
+    def clear(self) -> None:
+        """Clear all stored patterns."""
+        self._db.execute("DELETE FROM string_validations")
+        self._db.commit()
+
+    def close(self) -> None:
+        """Close database connection and cleanup tempfile if used."""
+        self._db.close()
+        if self._tempfile:
+            self._tempfile.close()

--- a/src/linters/stringly_typed/storage_initializer.py
+++ b/src/linters/stringly_typed/storage_initializer.py
@@ -1,0 +1,45 @@
+"""
+Purpose: Storage initialization for stringly-typed linter
+
+Scope: Initializes StringlyTypedStorage with SQLite storage
+
+Overview: Handles storage initialization for stringly-typed pattern detection. Creates SQLite
+    storage in memory mode for efficient cross-file analysis during a single linter run.
+    Separates initialization logic from main linter rule to maintain SRP compliance.
+
+Dependencies: BaseLintContext, StringlyTypedConfig, StringlyTypedStorage
+
+Exports: StorageInitializer class
+
+Interfaces: StorageInitializer.initialize(context, config) -> StringlyTypedStorage
+
+Implementation: Creates StringlyTypedStorage with memory mode for fast in-memory storage
+"""
+
+from src.core.base import BaseLintContext
+
+from .config import StringlyTypedConfig
+from .storage import StringlyTypedStorage
+
+
+class StorageInitializer:
+    """Initializes storage for stringly-typed pattern detection."""
+
+    def initialize(
+        self, context: BaseLintContext, config: StringlyTypedConfig
+    ) -> StringlyTypedStorage:
+        """Initialize storage based on configuration.
+
+        Args:
+            context: Lint context (reserved for future use)
+            config: Stringly-typed configuration (reserved for future storage_mode)
+
+        Returns:
+            StringlyTypedStorage instance with SQLite storage
+        """
+        # Context and config reserved for future storage_mode configuration
+        _ = context
+        _ = config
+
+        # Create SQLite storage in memory mode
+        return StringlyTypedStorage(storage_mode="memory")

--- a/src/linters/stringly_typed/violation_generator.py
+++ b/src/linters/stringly_typed/violation_generator.py
@@ -1,0 +1,205 @@
+"""
+Purpose: Violation generation from cross-file stringly-typed patterns
+
+Scope: Generates violations from duplicate pattern hashes across files
+
+Overview: Handles violation generation for stringly-typed patterns that appear across multiple
+    files. Queries storage for duplicate hashes, retrieves patterns for each hash, builds
+    violations with cross-references to other files, and filters patterns based on enum value
+    thresholds. Separates violation generation logic from main linter rule to maintain SRP
+    compliance.
+
+Dependencies: StringlyTypedStorage, StoredPattern, StringlyTypedConfig, Violation, Severity
+
+Exports: ViolationGenerator class
+
+Interfaces: ViolationGenerator.generate_violations(storage, rule_id, config) -> list[Violation]
+
+Implementation: Queries storage, validates pattern thresholds, builds violations with
+    cross-file references
+"""
+
+from src.core.types import Severity, Violation
+
+from .config import StringlyTypedConfig
+from .ignore_utils import is_ignored
+from .storage import StoredPattern, StringlyTypedStorage
+
+
+def _filter_by_ignore(violations: list[Violation], ignore: list[str]) -> list[Violation]:
+    """Filter violations by ignore patterns."""
+    if not ignore:
+        return violations
+    return [v for v in violations if not is_ignored(v.file_path, ignore)]
+
+
+class ViolationGenerator:
+    """Generates violations from cross-file stringly-typed patterns."""
+
+    def generate_violations(
+        self,
+        storage: StringlyTypedStorage,
+        rule_id: str,
+        config: StringlyTypedConfig,
+    ) -> list[Violation]:
+        """Generate violations from storage.
+
+        Args:
+            storage: Pattern storage instance
+            rule_id: Rule identifier for violations
+            config: Stringly-typed configuration with thresholds
+
+        Returns:
+            List of violations for patterns appearing in multiple files
+        """
+        duplicate_hashes = storage.get_duplicate_hashes(min_files=config.min_occurrences)
+        violations: list[Violation] = []
+
+        for hash_value in duplicate_hashes:
+            patterns = storage.get_patterns_by_hash(hash_value)
+            if self._should_skip_patterns(patterns, config):
+                continue
+            violations.extend(self._build_violation(p, patterns, rule_id) for p in patterns)
+
+        return _filter_by_ignore(violations, config.ignore)
+
+    def _should_skip_patterns(
+        self, patterns: list[StoredPattern], config: StringlyTypedConfig
+    ) -> bool:
+        """Check if pattern group should be skipped based on config.
+
+        Args:
+            patterns: List of patterns with same hash
+            config: Configuration with thresholds
+
+        Returns:
+            True if patterns should be skipped
+        """
+        if not patterns:
+            return True
+        first = patterns[0]
+        return not self._is_enum_candidate(first, config) or self._is_allowed_string_set(
+            first, config
+        )
+
+    def _is_enum_candidate(self, pattern: StoredPattern, config: StringlyTypedConfig) -> bool:
+        """Check if pattern's value count is within enum range.
+
+        Args:
+            pattern: Pattern to check
+            config: Configuration with enum thresholds
+
+        Returns:
+            True if value count is suitable for enum suggestion
+        """
+        value_count = len(pattern.string_values)
+        return config.min_values_for_enum <= value_count <= config.max_values_for_enum
+
+    def _is_allowed_string_set(self, pattern: StoredPattern, config: StringlyTypedConfig) -> bool:
+        """Check if pattern's string set is in allowed list.
+
+        Args:
+            pattern: Pattern to check
+            config: Configuration with allowed string sets
+
+        Returns:
+            True if string set is explicitly allowed
+        """
+        pattern_set = set(pattern.string_values)
+        for allowed_set in config.allowed_string_sets:
+            if pattern_set == set(allowed_set):
+                return True
+        return False
+
+    def _build_violation(
+        self,
+        pattern: StoredPattern,
+        all_patterns: list[StoredPattern],
+        rule_id: str,
+    ) -> Violation:
+        """Build a violation for a pattern with cross-references.
+
+        Args:
+            pattern: The pattern to create violation for
+            all_patterns: All patterns with same hash (for cross-references)
+            rule_id: Rule identifier
+
+        Returns:
+            Violation instance
+        """
+        message = self._build_message(pattern, all_patterns)
+        suggestion = self._build_suggestion(pattern)
+
+        return Violation(
+            rule_id=rule_id,
+            file_path=str(pattern.file_path),
+            line=pattern.line_number,
+            column=pattern.column,
+            message=message,
+            severity=Severity.ERROR,
+            suggestion=suggestion,
+        )
+
+    def _build_message(self, pattern: StoredPattern, all_patterns: list[StoredPattern]) -> str:
+        """Build violation message with cross-file references.
+
+        Args:
+            pattern: The primary pattern
+            all_patterns: All patterns with same hash
+
+        Returns:
+            Human-readable violation message
+        """
+        # Get unique file count
+        file_count = len({p.file_path for p in all_patterns})
+
+        # Format string values
+        values_str = ", ".join(f"'{v}'" for v in sorted(pattern.string_values))
+
+        # Build cross-references (excluding current file)
+        other_refs = self._build_cross_references(pattern, all_patterns)
+
+        message = (
+            f"Stringly-typed pattern with values [{values_str}] appears in {file_count} files."
+        )
+
+        if other_refs:
+            message += f" Also found in: {other_refs}."
+
+        return message
+
+    def _build_cross_references(
+        self, pattern: StoredPattern, all_patterns: list[StoredPattern]
+    ) -> str:
+        """Build cross-reference string for other files.
+
+        Args:
+            pattern: Current pattern
+            all_patterns: All patterns with same hash
+
+        Returns:
+            Comma-separated list of file:line references
+        """
+        refs = []
+        for other in all_patterns:
+            if other.file_path != pattern.file_path:
+                refs.append(f"{other.file_path.name}:{other.line_number}")
+
+        return ", ".join(refs)
+
+    def _build_suggestion(self, pattern: StoredPattern) -> str:
+        """Build fix suggestion for the pattern.
+
+        Args:
+            pattern: The pattern to suggest fix for
+
+        Returns:
+            Human-readable suggestion
+        """
+        values_count = len(pattern.string_values)
+        var_info = f" for '{pattern.variable_name}'" if pattern.variable_name else ""
+
+        return (
+            f"Consider defining an enum or type union{var_info} with the "
+            f"{values_count} possible values instead of using string literals."
+        )

--- a/tests/unit/linters/stringly_typed/test_cross_file_detection.py
+++ b/tests/unit/linters/stringly_typed/test_cross_file_detection.py
@@ -1,0 +1,498 @@
+"""
+Purpose: Integration tests for cross-file stringly-typed pattern detection
+
+Scope: Multi-file pattern detection using StringlyTypedRule
+
+Overview: Comprehensive test suite for cross-file stringly-typed pattern detection covering
+    scenarios with patterns spanning multiple files, different pattern types, and configuration
+    options. Validates proper cross-referencing in violation messages and threshold behavior.
+
+Dependencies: pytest, pathlib, StringlyTypedRule, FileLintContext
+
+Exports: Test functions for cross-file detection scenarios
+
+Interfaces: Tests use StringlyTypedRule directly with FileLintContext
+
+Implementation: Uses tmp_path for isolated file fixtures, tests rule directly
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.linters.stringly_typed import StringlyTypedRule
+from src.orchestrator.core import FileLintContext
+
+
+@pytest.fixture
+def rule() -> StringlyTypedRule:
+    """Create a fresh rule instance for each test."""
+    return StringlyTypedRule()
+
+
+def create_context(
+    file_path: Path, language: str = "python", config: dict | None = None
+) -> FileLintContext:
+    """Create a FileLintContext for testing.
+
+    Args:
+        file_path: Path to the file
+        language: Programming language
+        config: Optional stringly_typed config dict
+
+    Returns:
+        FileLintContext instance
+    """
+    content = file_path.read_text() if file_path.exists() else ""
+    metadata = {"stringly_typed": config or {}}
+    return FileLintContext(file_path, language, content, metadata)
+
+
+class TestCrossFileDetection:
+    """Tests for cross-file pattern detection."""
+
+    def test_same_pattern_in_two_files_generates_violations(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Two files with same string pattern should generate violations."""
+        # Create file 1 with membership validation
+        file1 = tmp_path / "module1.py"
+        file1.write_text("""
+def check_env(env: str) -> bool:
+    if env in ("staging", "production"):
+        return True
+    return False
+""")
+
+        # Create file 2 with same pattern
+        file2 = tmp_path / "module2.py"
+        file2.write_text("""
+def validate_env(env: str) -> None:
+    if env not in ("staging", "production"):
+        raise ValueError("Invalid env")
+""")
+
+        # Process both files
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        # Get violations
+        violations = rule.finalize()
+
+        # Should have 2 violations (one per file)
+        assert len(violations) == 2
+        violation_files = {Path(v.file_path).name for v in violations}
+        assert "module1.py" in violation_files
+        assert "module2.py" in violation_files
+
+    def test_pattern_in_three_files_generates_violations(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Pattern appearing in 3 files should generate 3 violations."""
+        pattern_values = '("active", "inactive", "pending")'
+
+        for i in range(3):
+            file = tmp_path / f"module{i}.py"
+            file.write_text(f"""
+def check_status_{i}(status: str) -> bool:
+    return status in {pattern_values}
+""")
+
+        # Process all files
+        for i in range(3):
+            ctx = create_context(tmp_path / f"module{i}.py")
+            rule.check(ctx)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 3
+
+    def test_single_file_no_violation_with_require_cross_file(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Single file should not generate violation when require_cross_file=True."""
+        file1 = tmp_path / "single.py"
+        file1.write_text("""
+def check_mode(mode: str) -> bool:
+    return mode in ("debug", "release")
+""")
+
+        ctx = create_context(file1, config={"require_cross_file": True})
+        rule.check(ctx)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 0
+
+    def test_different_patterns_no_cross_file_match(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Different string patterns should not match across files."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text("""
+def check_env(env: str) -> bool:
+    return env in ("staging", "production")
+""")
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text("""
+def check_mode(mode: str) -> bool:
+    return mode in ("debug", "release")
+""")
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Different patterns, no cross-file match
+        assert len(violations) == 0
+
+    def test_same_values_different_order_matches(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Same values in different order should match (hash normalization)."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text("""
+def check1(x: str) -> bool:
+    return x in ("alpha", "beta", "gamma")
+""")
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text("""
+def check2(x: str) -> bool:
+    return x in ("gamma", "alpha", "beta")
+""")
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Same values in different order should match
+        assert len(violations) == 2
+
+    def test_case_normalized_matching(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Values should match regardless of case (lowercase normalization)."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text("""
+def check1(x: str) -> bool:
+    return x in ("Active", "Inactive")
+""")
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text("""
+def check2(x: str) -> bool:
+    return x in ("active", "inactive")
+""")
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Case-insensitive matching for hash
+        assert len(violations) == 2
+
+
+class TestMinOccurrencesThreshold:
+    """Tests for min_occurrences configuration."""
+
+    def test_respects_min_occurrences_threshold(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Pattern in 2 files with min_occurrences=3 should not flag."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text('x = status in ("a", "b")')
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text('y = status in ("a", "b")')
+
+        config = {"min_occurrences": 3}
+        ctx1 = create_context(file1, config=config)
+        ctx2 = create_context(file2, config=config)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Only 2 files but min_occurrences is 3
+        assert len(violations) == 0
+
+    def test_meets_min_occurrences_threshold(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Pattern in 3 files with min_occurrences=3 should flag."""
+        for i in range(3):
+            file = tmp_path / f"module{i}.py"
+            file.write_text(f'x{i} = status in ("a", "b", "c")')
+
+        config = {"min_occurrences": 3}
+
+        for i in range(3):
+            ctx = create_context(tmp_path / f"module{i}.py", config=config)
+            rule.check(ctx)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 3
+
+
+class TestEnumValueThresholds:
+    """Tests for min/max_values_for_enum configuration."""
+
+    def test_too_few_values_not_flagged(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Pattern with 1 value should not be flagged (min_values_for_enum=2)."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text('x = status in ("single",)')
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text('y = status in ("single",)')
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Only 1 value, below min_values_for_enum=2
+        assert len(violations) == 0
+
+    def test_too_many_values_not_flagged(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Pattern with 7+ values should not be flagged (max_values_for_enum=6)."""
+        values = '("a", "b", "c", "d", "e", "f", "g")'
+
+        file1 = tmp_path / "module1.py"
+        file1.write_text(f"x = status in {values}")
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text(f"y = status in {values}")
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # 7 values, above max_values_for_enum=6
+        assert len(violations) == 0
+
+
+class TestAllowedStringSets:
+    """Tests for allowed_string_sets configuration."""
+
+    def test_allowed_string_set_not_flagged(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Patterns in allowed_string_sets should not be flagged."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text('x = env in ("dev", "staging", "prod")')
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text('y = env in ("dev", "staging", "prod")')
+
+        config = {"allowed_string_sets": [["dev", "staging", "prod"]]}
+        ctx1 = create_context(file1, config=config)
+        ctx2 = create_context(file2, config=config)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 0
+
+
+class TestViolationMessages:
+    """Tests for violation message content."""
+
+    def test_violation_message_contains_values(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Violation message should contain the string values."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text('x = mode in ("fast", "slow")')
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text('y = mode in ("fast", "slow")')
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 2
+        for v in violations:
+            assert "fast" in v.message
+            assert "slow" in v.message
+
+    def test_violation_message_contains_file_count(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Violation message should mention number of files."""
+        for i in range(3):
+            file = tmp_path / f"module{i}.py"
+            file.write_text(f'x{i} = status in ("active", "inactive")')
+
+        for i in range(3):
+            ctx = create_context(tmp_path / f"module{i}.py")
+            rule.check(ctx)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 3
+        for v in violations:
+            assert "3 files" in v.message
+
+    def test_violation_contains_cross_references(
+        self, rule: StringlyTypedRule, tmp_path: Path
+    ) -> None:
+        """Violation message should reference other files with same pattern."""
+        file1 = tmp_path / "first.py"
+        file1.write_text('x = status in ("on", "off")')
+
+        file2 = tmp_path / "second.py"
+        file2.write_text('y = status in ("on", "off")')
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Find violation for first.py
+        first_violation = next(v for v in violations if "first.py" in v.file_path)
+        assert "second.py" in first_violation.message
+
+        # Find violation for second.py
+        second_violation = next(v for v in violations if "second.py" in v.file_path)
+        assert "first.py" in second_violation.message
+
+
+class TestIgnorePatterns:
+    """Tests for ignore pattern configuration."""
+
+    def test_ignored_files_not_flagged(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Files matching ignore patterns should not generate violations."""
+        file1 = tmp_path / "src" / "module.py"
+        file1.parent.mkdir(parents=True, exist_ok=True)
+        file1.write_text('x = status in ("a", "b")')
+
+        file2 = tmp_path / "tests" / "test_module.py"
+        file2.parent.mkdir(parents=True, exist_ok=True)
+        file2.write_text('y = status in ("a", "b")')
+
+        config = {"ignore": ["tests/"]}
+        ctx1 = create_context(file1, config=config)
+        ctx2 = create_context(file2, config=config)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        # Only src/module.py should potentially have violations
+        # But since we ignore tests/, there's only 1 file, which means no cross-file match
+        assert len(violations) == 0
+
+
+class TestRuleReset:
+    """Tests for rule state reset between runs."""
+
+    def test_rule_reset_between_runs(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Rule should reset state between finalize() calls."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text('x = status in ("a", "b")')
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text('y = status in ("a", "b")')
+
+        # First run
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations1 = rule.finalize()
+        assert len(violations1) == 2
+
+        # Second run with new files
+        file3 = tmp_path / "module3.py"
+        file3.write_text('a = mode in ("x", "y", "z")')
+
+        file4 = tmp_path / "module4.py"
+        file4.write_text('b = mode in ("x", "y", "z")')
+
+        ctx3 = create_context(file3)
+        ctx4 = create_context(file4)
+
+        rule.check(ctx3)
+        rule.check(ctx4)
+
+        violations2 = rule.finalize()
+
+        # Should only contain new files, not old ones
+        assert len(violations2) == 2
+        violation_files = {Path(v.file_path).name for v in violations2}
+        assert "module3.py" in violation_files
+        assert "module4.py" in violation_files
+        assert "module1.py" not in violation_files
+
+
+class TestEqualityChainPatterns:
+    """Tests for equality chain pattern detection."""
+
+    def test_equality_chain_cross_file(self, rule: StringlyTypedRule, tmp_path: Path) -> None:
+        """Equality chains with same values should match across files."""
+        file1 = tmp_path / "module1.py"
+        file1.write_text("""
+def process1(status: str) -> int:
+    if status == "success":
+        return 1
+    elif status == "failure":
+        return 2
+    elif status == "pending":
+        return 3
+    return 0
+""")
+
+        file2 = tmp_path / "module2.py"
+        file2.write_text("""
+def process2(status: str) -> str:
+    if status == "success":
+        return "ok"
+    elif status == "failure":
+        return "error"
+    elif status == "pending":
+        return "wait"
+    return ""
+""")
+
+        ctx1 = create_context(file1)
+        ctx2 = create_context(file2)
+
+        rule.check(ctx1)
+        rule.check(ctx2)
+
+        violations = rule.finalize()
+
+        assert len(violations) == 2

--- a/tests/unit/linters/stringly_typed/test_storage.py
+++ b/tests/unit/linters/stringly_typed/test_storage.py
@@ -1,0 +1,509 @@
+"""
+Purpose: Unit tests for stringly-typed pattern storage
+
+Scope: Test SQLite storage operations for cross-file pattern detection
+
+Overview: Tests the StringlyTypedStorage class that manages SQLite storage for
+    stringly-typed pattern detection. Verifies pattern insertion, retrieval,
+    duplicate hash detection, and storage lifecycle operations. Covers both
+    memory and tempfile storage modes.
+
+Dependencies: pytest, pathlib.Path, storage module
+
+Exports: Test functions for storage validation
+
+Interfaces: pytest test functions
+
+Implementation: Unit tests with isolated storage instances per test
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.linters.stringly_typed.storage import StoredPattern, StringlyTypedStorage
+
+
+@pytest.fixture
+def storage() -> StringlyTypedStorage:
+    """Create a fresh storage instance for each test."""
+    store = StringlyTypedStorage(storage_mode="memory")
+    yield store
+    store.close()
+
+
+@pytest.fixture
+def sample_pattern() -> StoredPattern:
+    """Create a sample pattern for testing."""
+    return StoredPattern(
+        file_path=Path("/test/module1.py"),
+        line_number=10,
+        column=4,
+        variable_name="env",
+        string_set_hash=hash(("production", "staging")),
+        string_values=["production", "staging"],
+        pattern_type="membership_validation",
+        details="Membership validation on 'env' with 2 values",
+    )
+
+
+class TestStoredPatternDataclass:
+    """Tests for StoredPattern dataclass."""
+
+    def test_stored_pattern_creation(self) -> None:
+        """Test creating a StoredPattern with all fields."""
+        pattern = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=5,
+            column=0,
+            variable_name="status",
+            string_set_hash=12345,
+            string_values=["active", "inactive"],
+            pattern_type="equality_chain",
+            details="Equality chain with 2 values",
+        )
+
+        assert pattern.file_path == Path("/test/file.py")
+        assert pattern.line_number == 5
+        assert pattern.column == 0
+        assert pattern.variable_name == "status"
+        assert pattern.string_set_hash == 12345
+        assert pattern.string_values == ["active", "inactive"]
+        assert pattern.pattern_type == "equality_chain"
+        assert pattern.details == "Equality chain with 2 values"
+
+    def test_stored_pattern_with_none_variable(self) -> None:
+        """Test pattern with None variable name."""
+        pattern = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=5,
+            column=0,
+            variable_name=None,
+            string_set_hash=12345,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="Pattern details",
+        )
+
+        assert pattern.variable_name is None
+
+
+class TestStringlyTypedStorageInit:
+    """Tests for storage initialization."""
+
+    def test_memory_mode_initialization(self) -> None:
+        """Test storage initializes with memory mode."""
+        store = StringlyTypedStorage(storage_mode="memory")
+        assert store._storage_mode == "memory"
+        store.close()
+
+    def test_tempfile_mode_initialization(self) -> None:
+        """Test storage initializes with tempfile mode."""
+        store = StringlyTypedStorage(storage_mode="tempfile")
+        assert store._storage_mode == "tempfile"
+        assert store._tempfile is not None
+        store.close()
+
+    def test_invalid_mode_raises_error(self) -> None:
+        """Test invalid storage mode raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid storage_mode"):
+            StringlyTypedStorage(storage_mode="invalid")
+
+
+class TestAddPattern:
+    """Tests for adding patterns to storage."""
+
+    def test_add_single_pattern(
+        self, storage: StringlyTypedStorage, sample_pattern: StoredPattern
+    ) -> None:
+        """Test adding a single pattern."""
+        storage.add_pattern(sample_pattern)
+
+        patterns = storage.get_all_patterns()
+        assert len(patterns) == 1
+        assert patterns[0].file_path == sample_pattern.file_path
+        assert patterns[0].line_number == sample_pattern.line_number
+
+    def test_add_multiple_patterns_individually(self, storage: StringlyTypedStorage) -> None:
+        """Test adding multiple patterns one at a time."""
+        pattern1 = StoredPattern(
+            file_path=Path("/test/file1.py"),
+            line_number=10,
+            column=0,
+            variable_name="status",
+            string_set_hash=111,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="Details 1",
+        )
+        pattern2 = StoredPattern(
+            file_path=Path("/test/file2.py"),
+            line_number=20,
+            column=4,
+            variable_name="mode",
+            string_set_hash=222,
+            string_values=["x", "y"],
+            pattern_type="equality_chain",
+            details="Details 2",
+        )
+
+        storage.add_pattern(pattern1)
+        storage.add_pattern(pattern2)
+
+        patterns = storage.get_all_patterns()
+        assert len(patterns) == 2
+
+    def test_add_patterns_batch(self, storage: StringlyTypedStorage) -> None:
+        """Test adding patterns in a batch."""
+        patterns = [
+            StoredPattern(
+                file_path=Path(f"/test/file{i}.py"),
+                line_number=i * 10,
+                column=0,
+                variable_name=f"var{i}",
+                string_set_hash=i * 100,
+                string_values=["a", "b"],
+                pattern_type="membership_validation",
+                details=f"Details {i}",
+            )
+            for i in range(5)
+        ]
+
+        storage.add_patterns(patterns)
+
+        stored = storage.get_all_patterns()
+        assert len(stored) == 5
+
+    def test_add_empty_patterns_list(self, storage: StringlyTypedStorage) -> None:
+        """Test adding empty list does nothing."""
+        storage.add_patterns([])
+
+        patterns = storage.get_all_patterns()
+        assert len(patterns) == 0
+
+    def test_replace_pattern_on_same_location(self, storage: StringlyTypedStorage) -> None:
+        """Test pattern is replaced when same file/line/column."""
+        pattern1 = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=10,
+            column=0,
+            variable_name="status",
+            string_set_hash=111,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="First pattern",
+        )
+        pattern2 = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=10,
+            column=0,
+            variable_name="status",
+            string_set_hash=222,
+            string_values=["x", "y", "z"],
+            pattern_type="equality_chain",
+            details="Replaced pattern",
+        )
+
+        storage.add_pattern(pattern1)
+        storage.add_pattern(pattern2)
+
+        patterns = storage.get_all_patterns()
+        assert len(patterns) == 1
+        assert patterns[0].details == "Replaced pattern"
+        assert patterns[0].string_set_hash == 222
+
+
+class TestGetDuplicateHashes:
+    """Tests for finding duplicate hashes across files."""
+
+    def test_no_duplicates_returns_empty(self, storage: StringlyTypedStorage) -> None:
+        """Test empty storage returns no duplicates."""
+        hashes = storage.get_duplicate_hashes()
+        assert hashes == []
+
+    def test_single_pattern_no_duplicate(
+        self, storage: StringlyTypedStorage, sample_pattern: StoredPattern
+    ) -> None:
+        """Test single pattern is not considered duplicate."""
+        storage.add_pattern(sample_pattern)
+
+        hashes = storage.get_duplicate_hashes()
+        assert hashes == []
+
+    def test_same_hash_in_two_files_is_duplicate(self, storage: StringlyTypedStorage) -> None:
+        """Test same hash in different files is flagged as duplicate."""
+        common_hash = hash(("staging", "production"))
+        pattern1 = StoredPattern(
+            file_path=Path("/test/file1.py"),
+            line_number=10,
+            column=0,
+            variable_name="env",
+            string_set_hash=common_hash,
+            string_values=["production", "staging"],
+            pattern_type="membership_validation",
+            details="Pattern in file 1",
+        )
+        pattern2 = StoredPattern(
+            file_path=Path("/test/file2.py"),
+            line_number=20,
+            column=0,
+            variable_name="environment",
+            string_set_hash=common_hash,
+            string_values=["production", "staging"],
+            pattern_type="membership_validation",
+            details="Pattern in file 2",
+        )
+
+        storage.add_patterns([pattern1, pattern2])
+
+        hashes = storage.get_duplicate_hashes()
+        assert len(hashes) == 1
+        assert common_hash in hashes
+
+    def test_same_hash_same_file_not_duplicate(self, storage: StringlyTypedStorage) -> None:
+        """Test same hash in same file on different lines is not a cross-file duplicate."""
+        common_hash = hash(("a", "b"))
+        pattern1 = StoredPattern(
+            file_path=Path("/test/file1.py"),
+            line_number=10,
+            column=0,
+            variable_name="x",
+            string_set_hash=common_hash,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="First pattern",
+        )
+        pattern2 = StoredPattern(
+            file_path=Path("/test/file1.py"),
+            line_number=20,
+            column=0,
+            variable_name="y",
+            string_set_hash=common_hash,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="Second pattern",
+        )
+
+        storage.add_patterns([pattern1, pattern2])
+
+        # Both patterns are in same file, so not a cross-file duplicate
+        hashes = storage.get_duplicate_hashes(min_files=2)
+        assert hashes == []
+
+    def test_min_files_threshold(self, storage: StringlyTypedStorage) -> None:
+        """Test min_files parameter filters correctly."""
+        common_hash = 12345
+        patterns = [
+            StoredPattern(
+                file_path=Path(f"/test/file{i}.py"),
+                line_number=10,
+                column=0,
+                variable_name="x",
+                string_set_hash=common_hash,
+                string_values=["a", "b"],
+                pattern_type="membership_validation",
+                details=f"Pattern {i}",
+            )
+            for i in range(2)  # Only 2 files
+        ]
+
+        storage.add_patterns(patterns)
+
+        # With min_files=3, should not be considered duplicate
+        assert storage.get_duplicate_hashes(min_files=3) == []
+
+        # With min_files=2, should be considered duplicate
+        assert storage.get_duplicate_hashes(min_files=2) == [common_hash]
+
+
+class TestGetPatternsByHash:
+    """Tests for retrieving patterns by hash value."""
+
+    def test_get_patterns_no_matches(self, storage: StringlyTypedStorage) -> None:
+        """Test getting patterns with non-existent hash."""
+        patterns = storage.get_patterns_by_hash(99999)
+        assert patterns == []
+
+    def test_get_patterns_single_match(
+        self, storage: StringlyTypedStorage, sample_pattern: StoredPattern
+    ) -> None:
+        """Test getting patterns with single match."""
+        storage.add_pattern(sample_pattern)
+
+        patterns = storage.get_patterns_by_hash(sample_pattern.string_set_hash)
+        assert len(patterns) == 1
+        assert patterns[0].file_path == sample_pattern.file_path
+
+    def test_get_patterns_multiple_matches(self, storage: StringlyTypedStorage) -> None:
+        """Test getting patterns with multiple matches."""
+        common_hash = 12345
+        pattern1 = StoredPattern(
+            file_path=Path("/test/file1.py"),
+            line_number=10,
+            column=0,
+            variable_name="x",
+            string_set_hash=common_hash,
+            string_values=["a", "b"],
+            pattern_type="membership_validation",
+            details="Pattern 1",
+        )
+        pattern2 = StoredPattern(
+            file_path=Path("/test/file2.py"),
+            line_number=20,
+            column=0,
+            variable_name="y",
+            string_set_hash=common_hash,
+            string_values=["a", "b"],
+            pattern_type="equality_chain",
+            details="Pattern 2",
+        )
+
+        storage.add_patterns([pattern1, pattern2])
+
+        patterns = storage.get_patterns_by_hash(common_hash)
+        assert len(patterns) == 2
+
+    def test_patterns_ordered_by_file_and_line(self, storage: StringlyTypedStorage) -> None:
+        """Test patterns are returned ordered by file path and line number."""
+        common_hash = 12345
+        patterns_to_add = [
+            StoredPattern(
+                file_path=Path("/test/z_file.py"),
+                line_number=30,
+                column=0,
+                variable_name="x",
+                string_set_hash=common_hash,
+                string_values=["a", "b"],
+                pattern_type="membership_validation",
+                details="Last",
+            ),
+            StoredPattern(
+                file_path=Path("/test/a_file.py"),
+                line_number=10,
+                column=0,
+                variable_name="x",
+                string_set_hash=common_hash,
+                string_values=["a", "b"],
+                pattern_type="membership_validation",
+                details="First",
+            ),
+            StoredPattern(
+                file_path=Path("/test/a_file.py"),
+                line_number=5,
+                column=0,
+                variable_name="x",
+                string_set_hash=common_hash,
+                string_values=["a", "b"],
+                pattern_type="membership_validation",
+                details="Actually first",
+            ),
+        ]
+
+        storage.add_patterns(patterns_to_add)
+
+        patterns = storage.get_patterns_by_hash(common_hash)
+        assert len(patterns) == 3
+        assert patterns[0].details == "Actually first"
+        assert patterns[1].details == "First"
+        assert patterns[2].details == "Last"
+
+
+class TestClearAndClose:
+    """Tests for storage cleanup operations."""
+
+    def test_clear_removes_all_patterns(
+        self, storage: StringlyTypedStorage, sample_pattern: StoredPattern
+    ) -> None:
+        """Test clear removes all stored patterns."""
+        storage.add_pattern(sample_pattern)
+        assert len(storage.get_all_patterns()) == 1
+
+        storage.clear()
+
+        assert len(storage.get_all_patterns()) == 0
+
+    def test_clear_allows_reuse(
+        self, storage: StringlyTypedStorage, sample_pattern: StoredPattern
+    ) -> None:
+        """Test storage can be reused after clear."""
+        storage.add_pattern(sample_pattern)
+        storage.clear()
+
+        # Add new pattern after clear
+        new_pattern = StoredPattern(
+            file_path=Path("/test/new.py"),
+            line_number=1,
+            column=0,
+            variable_name="new",
+            string_set_hash=999,
+            string_values=["new"],
+            pattern_type="membership_validation",
+            details="New pattern",
+        )
+        storage.add_pattern(new_pattern)
+
+        patterns = storage.get_all_patterns()
+        assert len(patterns) == 1
+        assert patterns[0].variable_name == "new"
+
+
+class TestStringValuesSerialization:
+    """Tests for JSON serialization of string values."""
+
+    def test_string_values_roundtrip(self, storage: StringlyTypedStorage) -> None:
+        """Test string values are correctly serialized and deserialized."""
+        pattern = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=10,
+            column=0,
+            variable_name="status",
+            string_set_hash=12345,
+            string_values=["active", "inactive", "pending"],
+            pattern_type="membership_validation",
+            details="Test pattern",
+        )
+
+        storage.add_pattern(pattern)
+
+        retrieved = storage.get_all_patterns()[0]
+        assert retrieved.string_values == ["active", "inactive", "pending"]
+
+    def test_empty_string_values(self, storage: StringlyTypedStorage) -> None:
+        """Test empty string values list."""
+        pattern = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=10,
+            column=0,
+            variable_name=None,
+            string_set_hash=0,
+            string_values=[],
+            pattern_type="membership_validation",
+            details="Empty values",
+        )
+
+        storage.add_pattern(pattern)
+
+        retrieved = storage.get_all_patterns()[0]
+        assert retrieved.string_values == []
+
+    def test_special_characters_in_values(self, storage: StringlyTypedStorage) -> None:
+        """Test string values with special characters."""
+        pattern = StoredPattern(
+            file_path=Path("/test/file.py"),
+            line_number=10,
+            column=0,
+            variable_name="mode",
+            string_set_hash=12345,
+            string_values=['value with "quotes"', "value with\nnewline", "emoji: 🎉"],
+            pattern_type="membership_validation",
+            details="Special chars",
+        )
+
+        storage.add_pattern(pattern)
+
+        retrieved = storage.get_all_patterns()[0]
+        assert retrieved.string_values == [
+            'value with "quotes"',
+            "value with\nnewline",
+            "emoji: 🎉",
+        ]


### PR DESCRIPTION
## Summary

- Create SQLite storage wrapper with `StoredPattern` dataclass for cross-file pattern tracking
- Implement `storage_initializer.py` factory for memory/tempfile storage modes
- Implement `violation_generator.py` with cross-file reference messages
- Create `ignore_utils.py` for shared ignore pattern matching (DRY refactor)
- Implement `StringlyTypedRule` with two-phase `check()`/`finalize()` pattern
- Add 24 unit tests for storage layer
- Add 17 integration tests for cross-file detection scenarios
- Update module exports and progress tracker (50% complete - 5/10 PRs)

## Key Features

| Feature | Description |
|---------|-------------|
| Two-phase linting | `check()` stores patterns, `finalize()` generates violations |
| Hash-based matching | Case-insensitive normalization for cross-file detection |
| Configurable thresholds | `min_occurrences`, `min_values_for_enum`, `max_values_for_enum` |
| Ignore patterns | Support for `allowed_string_sets` and `ignore` config |
| Cross-references | Violation messages include other file locations |

## Files Changed

### New Files
- `src/linters/stringly_typed/storage.py` - SQLite storage with `StoredPattern` dataclass
- `src/linters/stringly_typed/storage_initializer.py` - Factory for storage instances
- `src/linters/stringly_typed/violation_generator.py` - Generates violations with cross-refs
- `src/linters/stringly_typed/ignore_utils.py` - Shared ignore pattern utilities
- `src/linters/stringly_typed/linter.py` - Main `StringlyTypedRule` class
- `tests/unit/linters/stringly_typed/test_storage.py` - 24 storage unit tests
- `tests/unit/linters/stringly_typed/test_cross_file_detection.py` - 17 integration tests

### Modified Files
- `src/linters/stringly_typed/__init__.py` - Updated exports
- `.roadmap/in-progress/stringly-typed-linter/PROGRESS_TRACKER.md` - Updated progress

## Test Plan

- [x] All 24 storage unit tests pass
- [x] All 17 cross-file detection integration tests pass
- [x] All 924 project tests pass
- [x] `just lint-full` passes (Pylint 10.00/10, Xenon A-grade)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)