### PR TITLE
docs(roadmap): Add lazy-ignores linter planning

### DIFF
--- a/.roadmap/planning/lazy-ignores/AI_CONTEXT.md
+++ b/.roadmap/planning/lazy-ignores/AI_CONTEXT.md
@@ -1,0 +1,451 @@
+# Lazy Ignores Linter - AI Context & Architecture
+
+**Purpose**: Comprehensive feature context and design decisions for the lazy-ignores linter
+
+**Scope**: Architecture, design rationale, integration points, patterns to follow
+
+**Overview**: This document provides deep architectural context for the lazy-ignores linter feature. It explains the header-based suppression model, detection strategies, and how this linter differs from simple pattern matching. Essential for understanding design decisions and maintaining consistency across implementation.
+
+**Dependencies**: File-header linter infrastructure, CLI patterns, core types
+
+**Exports**: Architecture documentation, design decisions, integration patterns
+
+**Related**: PROGRESS_TRACKER.md for status, PR_BREAKDOWN.md for implementation steps
+
+**Implementation**: Reference architecture for consistent implementation
+
+---
+
+## Feature Vision
+
+### The Problem
+
+AI agents (Claude, GPT, etc.) often take shortcuts when encountering linting errors:
+
+```python
+# AI agent encounters: "PLR0912: Too many branches (15 > 12)"
+# Instead of refactoring, adds:
+def complex_function():  # noqa: PLR0912
+    ...  # Still complex, now hidden from linters
+```
+
+This creates **hidden technical debt**:
+- The code remains complex
+- Future developers don't see the warning
+- The ignore has no justification
+- No human approved the shortcut
+
+### The Solution
+
+Require **explicit justification** in file headers with **human approval**:
+
+```python
+"""
+Purpose: State machine for WebSocket lifecycle
+
+Suppressions:
+    PLR0912: State machine inherently requires branching for 6 states
+             Approved by @steve in PR #123
+"""
+
+def handle_state():  # noqa: PLR0912
+    # Now justified and approved
+```
+
+---
+
+## Architecture
+
+### High-Level Flow
+
+```
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Parse Header   │────▶│ Find Ignores in  │────▶│ Match Against   │
+│  Suppressions   │     │ Code Body        │     │ Header Entries  │
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+                                                          │
+                              ┌────────────────────────────┤
+                              ▼                            ▼
+                    ┌─────────────────┐          ┌─────────────────┐
+                    │ Unjustified     │          │ Orphaned Header │
+                    │ Violation       │          │ Violation       │
+                    └─────────────────┘          └─────────────────┘
+```
+
+### Component Diagram
+
+```
+src/linters/lazy_ignores/
+├── __init__.py
+├── types.py                 # Data structures
+│   ├── IgnoreType (enum)
+│   ├── IgnoreDirective (dataclass)
+│   └── SuppressionEntry (dataclass)
+│
+├── config.py                # Configuration
+│   └── LazyIgnoresConfig
+│
+├── ignore_detector.py       # Base interface
+│   └── BaseIgnoreDetector (ABC)
+│
+├── python_analyzer.py       # Python detection
+│   └── PythonIgnoreDetector
+│       ├── find_ignores() -> list[IgnoreDirective]
+│       └── PATTERNS dict
+│
+├── typescript_analyzer.py   # TS/JS detection
+│   └── TypeScriptIgnoreDetector
+│
+├── header_parser.py         # Suppressions parsing
+│   └── SuppressionsParser
+│       ├── parse() -> dict[str, str]
+│       ├── normalize_rule_id()
+│       └── extract_header()
+│
+├── test_skip_detector.py    # Test skip detection
+│   └── TestSkipDetector
+│
+├── violation_builder.py     # Message formatting
+│   └── build_unjustified_violation()
+│   └── build_orphaned_violation()
+│
+└── linter.py                # Main orchestrator
+    └── LazyIgnoresRule
+        ├── check() -> list[Violation]
+        ├── _check_file()
+        ├── _find_unjustified()
+        └── _find_orphaned()
+```
+
+---
+
+## Design Decisions
+
+### Decision 1: Header-Based Declarations
+
+**Why headers instead of inline comments?**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Inline: `# noqa: PLR0912 - justification` | Easy to add | Scattered, hard to audit |
+| Header: `Suppressions: PLR0912: ...` | Centralized, auditable | Requires header format |
+
+**Choice**: Header-based for auditability and explicit human approval workflow.
+
+### Decision 2: Rule-Based (Not Line-Based)
+
+**Why one entry per rule, not per line?**
+
+```python
+# Option A: Line-based (rejected)
+Suppressions:
+    Line 45 PLR0912: reason
+    Line 67 PLR0912: reason  # Tedious, brittle
+
+# Option B: Rule-based (chosen)
+Suppressions:
+    PLR0912: reason  # Covers all PLR0912 in file
+```
+
+**Choice**: Rule-based because:
+- Less verbose
+- Survives line number changes
+- Forces holistic justification
+
+### Decision 3: Orphaned Detection
+
+**Why detect orphaned header entries?**
+
+```python
+"""
+Suppressions:
+    PLR0912: Old justification  # But no PLR0912 ignore in code!
+"""
+```
+
+**Choice**: Error on orphaned because:
+- Keeps headers synchronized with code
+- Prevents stale documentation
+- Indicates code was refactored but header wasn't updated
+
+### Decision 4: Test Skips as Violations
+
+**Why flag test skips?**
+
+AI agents often skip failing tests rather than fixing them:
+
+```python
+@pytest.mark.skip  # "I'll fix this later" - never happens
+def test_critical_feature():
+    ...
+```
+
+**Choice**: Require `reason=` parameter for all skips:
+
+```python
+@pytest.mark.skip(reason="Depends on external service - see #456")
+```
+
+### Decision 5: Agent-Friendly Error Messages
+
+**Why special error message format?**
+
+AI agents read error messages to decide next actions. Clear guidance prevents:
+- Adding inline justifications (wrong approach)
+- Adding ignores without asking human
+- Misunderstanding the approval requirement
+
+**Choice**: Error messages explicitly state:
+1. What to add (Suppressions section format)
+2. Where to add it (file header)
+3. Approval requirement (human must approve)
+
+---
+
+## Integration Points
+
+### Existing Infrastructure to Reuse
+
+| Component | Location | Usage |
+|-----------|----------|-------|
+| File header parsing | `src/linters/file_header/python_parser.py` | Extract header from Python files |
+| TypeScript parsing | `src/linters/file_header/typescript_parser.py` | Extract header from TS files |
+| Violation type | `src/core/types.py` | Standard violation dataclass |
+| CLI patterns | `src/cli/linters/code_patterns.py` | Command registration |
+| Output formatting | `src/core/cli_utils.py` | text/json/sarif |
+
+### New File Header Field
+
+Add `Suppressions:` as optional field to FILE_HEADER_STANDARDS.md:
+
+```python
+"""
+Purpose: ...
+Scope: ...
+Overview: ...
+Dependencies: ...
+Exports: ...
+Interfaces: ...
+Implementation: ...
+
+Suppressions:                    # NEW - Optional section
+    RULE_ID: Justification text
+"""
+```
+
+---
+
+## Pattern Detection Details
+
+### Python Patterns
+
+| Pattern | Regex | Captures |
+|---------|-------|----------|
+| noqa | `#\s*noqa(?::\s*([A-Z0-9,\s]+))?` | Rule IDs (optional) |
+| type:ignore | `#\s*type:\s*ignore(?:\[([^\]]+)\])?` | Error code (optional) |
+| pylint:disable | `#\s*pylint:\s*disable=([a-z0-9\-,]+)` | Rule names |
+| nosec | `#\s*nosec(?:\s+([A-Z0-9]+))?` | Bandit rule ID |
+
+### TypeScript/JavaScript Patterns
+
+| Pattern | Regex | Notes |
+|---------|-------|-------|
+| @ts-ignore | `//\s*@ts-ignore` | Single-line |
+| @ts-nocheck | `//\s*@ts-nocheck` | File-level |
+| @ts-expect-error | `//\s*@ts-expect-error` | Expected error |
+| eslint-disable | `//\s*eslint-disable(?:-next-line)?` | Line/block |
+| eslint-disable block | `/\*\s*eslint-disable` | Block comment |
+
+### Rule ID Normalization
+
+```python
+# These should all match the same suppression entry:
+"PLR0912" -> "plr0912"
+"plr0912" -> "plr0912"
+
+# These are distinct:
+"type:ignore[arg-type]" -> "type:ignore[arg-type]"
+"type:ignore[return-value]" -> "type:ignore[return-value]"
+
+# Multi-rule noqa:
+"# noqa: PLR0912, PLR0915" -> ["plr0912", "plr0915"]
+```
+
+---
+
+## Error Message Templates
+
+### Unjustified Ignore
+
+```
+lazy-ignores.unjustified  {file_path}:{line}:{column}  ERROR
+
+  Unjustified suppression found:
+    {raw_text}
+
+  Rule: {rule_id}
+
+  To fix, add an entry to the file header Suppressions section:
+
+      Suppressions:
+          {rule_id}: [Your justification here]
+
+  IMPORTANT: Adding suppressions requires human approval.
+  Do not add this entry without explicit permission from
+  a human reviewer. Ask first, then add if approved.
+```
+
+### Orphaned Suppression
+
+```
+lazy-ignores.orphaned  {file_path}:{header_line}  ERROR
+
+  Orphaned suppression in header:
+    {rule_id}: {justification}
+
+  This rule is declared in the Suppressions section but
+  no matching ignore directive was found in the code.
+
+  Either:
+  1. Remove the entry if the ignore was removed from code
+  2. Add the ignore directive if it's missing
+```
+
+### Test Skip Without Reason
+
+```
+lazy-ignores.test-skip  {file_path}:{line}:{column}  ERROR
+
+  Test skip without reason:
+    {raw_text}
+
+  All test skips must have a reason explaining why the test
+  is skipped and when it will be re-enabled.
+
+  Fix by adding a reason:
+    @pytest.mark.skip(reason="Description - see issue #XXX")
+```
+
+---
+
+## Configuration Schema
+
+```yaml
+# .thailint.yaml
+lazy-ignores:
+  # Pattern detection toggles
+  check_noqa: true
+  check_type_ignore: true
+  check_pylint_disable: true
+  check_nosec: true
+  check_ts_ignore: true
+  check_eslint_disable: true
+  check_test_skips: true
+
+  # Orphaned detection
+  check_orphaned: true
+
+  # File patterns to ignore
+  ignore_patterns:
+    - "tests/**"  # Don't enforce in test files
+    - "**/migrations/**"
+    - "**/__pycache__/**"
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+| Test File | Coverage |
+|-----------|----------|
+| test_python_ignore_detection.py | noqa, type:ignore, pylint, nosec |
+| test_typescript_detection.py | @ts-ignore, eslint-disable |
+| test_header_parser.py | Suppressions extraction |
+| test_orphaned_detection.py | Orphaned entry detection |
+| test_violation_messages.py | Agent-friendly formatting |
+| test_test_skip_detection.py | pytest.skip, it.skip |
+
+### Integration Tests
+
+| Test | Scenario |
+|------|----------|
+| test_full_python_file.py | Complete Python file with mixed patterns |
+| test_full_typescript_file.py | Complete TS file with mixed patterns |
+| test_cli_integration.py | CLI command with all options |
+| test_output_formats.py | text, json, sarif output |
+
+### Edge Cases
+
+- Empty files
+- Files without headers
+- Malformed Suppressions sections
+- Mixed ignore types on same line
+- Unicode in justifications
+- Very long files (performance)
+
+---
+
+## Relationship to Existing Linters
+
+| Linter | Focus | Relationship |
+|--------|-------|--------------|
+| file-header | Header field presence | lazy-ignores adds Suppressions field |
+| nesting | Code complexity | lazy-ignores checks noqa for nesting rules |
+| srp | Class responsibility | lazy-ignores checks noqa for srp rules |
+| magic-numbers | Numeric literals | lazy-ignores checks noqa for magic rules |
+
+The lazy-ignores linter is **meta** - it lints the linting suppressions themselves.
+
+---
+
+## Success Criteria
+
+### Must Have (P0)
+- [ ] Detects all Python ignore patterns
+- [ ] Detects all TypeScript/JavaScript patterns
+- [ ] Header Suppressions parsing works
+- [ ] Orphaned detection works
+- [ ] Error messages guide AI agents correctly
+- [ ] CLI command with all output formats
+
+### Should Have (P1)
+- [ ] Test skip detection
+- [ ] Configuration via .thailint.yaml
+- [ ] Dogfooding on thai-lint itself
+
+### Nice to Have (P2)
+- [ ] Auto-fix suggestions
+- [ ] IDE integration hints
+- [ ] Metrics/statistics output
+
+---
+
+## References
+
+### Survey Findings
+
+The design is based on surveying real projects:
+
+| Project | Findings |
+|---------|----------|
+| safeshell | Excellent - all 13 ignores justified |
+| durable-code-test | Good - mostly justified, few issues |
+| tubebuddy | Mixed - 8+ complexity ignores without justification |
+| tb-automation-py | Mixed - TODOs acknowledging risky type ignores |
+
+Key patterns that informed design:
+1. Complexity ignores (PLR0912/PLR0915) often unjustified
+2. TODOs like "may cause runtime exceptions" indicate lazy ignores
+3. Repeated identical ignores suggest systemic issues
+4. Well-documented projects have inline justification comments
+
+### Similar Tools
+
+| Tool | Approach | Difference |
+|------|----------|------------|
+| flake8-noqa | Validates noqa has correct codes | Doesn't require justification |
+| pylint-ignore | Manages ignore files | External file, not header-based |
+
+Our approach is unique in requiring **human-approved header declarations**.

--- a/.roadmap/planning/lazy-ignores/PROGRESS_TRACKER.md
+++ b/.roadmap/planning/lazy-ignores/PROGRESS_TRACKER.md
@@ -1,0 +1,173 @@
+# Lazy Ignores Linter - Progress Tracker & AI Agent Handoff Document
+
+**Purpose**: Primary AI agent handoff document for the lazy-ignores linter feature
+
+**Scope**: Detect unjustified linting ignores and test skips in AI-generated code. Enforces header-based suppression declarations with human approval requirements.
+
+**Overview**: This document tracks implementation progress for a new `thailint lazy-ignores` command that detects when AI agents add linting suppressions (`# noqa`, `# type: ignore`, etc.) without proper justification. Uses a header-based declaration model where suppressions must be documented in the file header's `Suppressions:` section. Includes TDD approach, dogfooding on thai-lint itself, and documentation for PyPI publishing.
+
+**Dependencies**: Existing file-header linter infrastructure (`src/linters/file_header/`), CLI patterns (`src/cli/linters/`)
+
+**Exports**: Progress tracking, implementation guidance, AI agent coordination
+
+**Related**: AI_CONTEXT.md for feature overview, PR_BREAKDOWN.md for detailed tasks
+
+**Implementation**: TDD-driven development with systematic validation and 8-PR breakdown
+
+---
+
+## Document Purpose
+
+This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignores linter. When starting work:
+1. **Read this document FIRST** to understand current progress
+2. **Check "Next PR to Implement"** for what to do
+3. **Reference PR_BREAKDOWN.md** for detailed instructions
+4. **Update this document** after completing each PR
+
+---
+
+## Current Status
+
+**Current PR**: PR1 - Core Infrastructure & Python Tests (TDD)
+**Infrastructure State**: Not started - no files created yet
+**Feature Target**: Production-ready linter with full test coverage, integrated into thai-lint quality gates
+
+---
+
+## Required Documents Location
+
+```
+.roadmap/planning/lazy-ignores/
+├── PROGRESS_TRACKER.md    # THIS FILE - Current progress and handoff notes
+├── PR_BREAKDOWN.md        # Detailed instructions for each PR
+└── AI_CONTEXT.md          # Feature architecture and design decisions
+```
+
+---
+
+## Next PR to Implement
+
+### START HERE: PR1 - Core Infrastructure & Python Tests (TDD)
+
+**Quick Summary**: Create failing tests that define the linter's expected behavior, plus minimal infrastructure (types, config).
+
+**Pre-flight Checklist**:
+- [ ] Read `.ai/howtos/how-to-add-linter.md`
+- [ ] Read `.ai/docs/FILE_HEADER_STANDARDS.md` for header format
+- [ ] Review test patterns in `tests/unit/linters/nesting/`
+- [ ] Review existing types in `src/core/types.py`
+
+**Prerequisites Complete**: N/A (first PR)
+
+**Detailed Steps**: See PR_BREAKDOWN.md → PR1 section
+
+---
+
+## Overall Progress
+
+**Total Completion**: 0% (0/8 PRs completed)
+
+```
+[░░░░░░░░░░] 0% Complete
+```
+
+---
+
+## PR Status Dashboard
+
+| PR | Title | Status | Completion | Complexity | Priority | Notes |
+|----|-------|--------|------------|------------|----------|-------|
+| PR1 | Core Infrastructure & Python Tests (TDD) | 🔴 Not Started | 0% | Medium | P0 | Tests first - all should fail initially |
+| PR2 | Python Ignore Detection | 🔴 Not Started | 0% | Medium | P0 | noqa, type:ignore, pylint, nosec |
+| PR3 | Header Suppressions Parser | 🔴 Not Started | 0% | Medium | P0 | Parse Suppressions: section from headers |
+| PR4 | TypeScript/JavaScript Detection | 🔴 Not Started | 0% | Medium | P1 | @ts-ignore, eslint-disable patterns |
+| PR5 | Test Skip Detection | 🔴 Not Started | 0% | Low | P1 | pytest.mark.skip, it.skip() |
+| PR6 | CLI Integration & Output Formats | 🔴 Not Started | 0% | Medium | P0 | Wire up CLI, text/json/sarif output |
+| PR7 | Dogfooding - Internal Use | 🔴 Not Started | 0% | Low | P1 | Add to just lint-full, fix own violations |
+| PR8 | Documentation & PyPI Prep | 🔴 Not Started | 0% | Low | P2 | README, examples, user docs |
+
+### Status Legend
+- 🔴 Not Started
+- 🟡 In Progress
+- 🟢 Complete
+- 🔵 Blocked
+- ⚫ Cancelled
+
+---
+
+## Implementation Strategy
+
+### TDD Approach
+1. **PR1**: Write failing tests that define behavior
+2. **PR2-5**: Implement features to make tests pass
+3. **PR6**: Integration and CLI
+4. **PR7**: Validate by using on ourselves
+5. **PR8**: Document for users
+
+### Quality Gates Per PR
+- [ ] All tests pass
+- [ ] Pylint score 10.00/10
+- [ ] Xenon A-grade complexity
+- [ ] No new violations introduced
+
+---
+
+## Success Metrics
+
+### Technical Metrics
+- [ ] 90%+ test coverage for lazy_ignores module
+- [ ] All output formats work (text, json, sarif)
+- [ ] Performance: < 100ms per file scanned
+- [ ] Zero false positives on legitimate patterns
+
+### Feature Metrics
+- [ ] Detects all common Python ignore patterns
+- [ ] Detects all common TypeScript/JavaScript patterns
+- [ ] Error messages guide AI agents correctly
+- [ ] Orphaned header entries detected
+
+---
+
+## Update Protocol
+
+After completing each PR:
+1. Update the PR status to 🟢 Complete
+2. Add commit hash to Notes column: "Description (commit abc1234)"
+3. Fill in completion percentage (100%)
+4. Update the "Next PR to Implement" section
+5. Update overall progress percentage and bar
+6. Commit changes to this document
+
+---
+
+## Notes for AI Agents
+
+### Critical Context
+- This linter enforces **header-based suppression declarations**
+- All ignores must be documented in file header `Suppressions:` section
+- Error messages must explicitly tell agents to **get human approval**
+- Orphaned entries (declared but not used) are violations
+
+### Common Pitfalls to Avoid
+- Don't add inline comments as justification - must be in header
+- Don't allow empty justifications
+- Don't forget to normalize rule IDs (PLR0912 vs plr0912)
+- Don't skip orphaned detection - staleness is important
+
+### Resources
+- Template linter: `src/linters/nesting/linter.py`
+- Header parsing: `src/linters/file_header/python_parser.py`
+- CLI patterns: `src/cli/linters/code_patterns.py`
+- Violation type: `src/core/types.py`
+
+---
+
+## Definition of Done
+
+The feature is complete when:
+- [ ] All 8 PRs merged to main
+- [ ] 90%+ test coverage
+- [ ] thai-lint passes its own lazy-ignores check
+- [ ] Documentation published in docs/
+- [ ] Added to `just lint-full` command
+- [ ] README.md updated with new linter

--- a/.roadmap/planning/lazy-ignores/PR_BREAKDOWN.md
+++ b/.roadmap/planning/lazy-ignores/PR_BREAKDOWN.md
@@ -1,0 +1,842 @@
+# Lazy Ignores Linter - PR Breakdown
+
+**Purpose**: Detailed implementation breakdown for the lazy-ignores linter
+
+**Scope**: 8 atomic pull requests from initial tests through documentation
+
+**Overview**: Comprehensive breakdown of the lazy-ignores linter into 8 manageable, atomic pull requests. Each PR is designed to be self-contained, testable, and maintains application functionality while incrementally building toward the complete feature. Uses TDD approach where PR1 creates failing tests and subsequent PRs implement features.
+
+**Dependencies**: Existing file-header linter, CLI infrastructure, core types
+
+**Exports**: PR implementation plans, file structures, testing strategies, success criteria
+
+**Related**: AI_CONTEXT.md for feature overview, PROGRESS_TRACKER.md for status tracking
+
+**Implementation**: TDD with atomic PRs, each independently testable and revertible
+
+---
+
+## Overview
+
+This document breaks down the lazy-ignores linter into 8 manageable PRs:
+
+| PR | Focus | Approach |
+|----|-------|----------|
+| PR1 | Tests & Infrastructure | TDD - Write failing tests first |
+| PR2 | Python Detection | Implement to pass tests |
+| PR3 | Header Parser | Implement to pass tests |
+| PR4 | TypeScript/JS Detection | Implement to pass tests |
+| PR5 | Test Skip Detection | Implement to pass tests |
+| PR6 | CLI Integration | Wire everything together |
+| PR7 | Dogfooding | Use on ourselves |
+| PR8 | Documentation | Prepare for release |
+
+---
+
+## PR1: Core Infrastructure & Python Tests (TDD)
+
+**Goal**: Write failing tests that define expected behavior, plus minimal types/config
+
+**Scope**: Test files, type definitions, configuration dataclass
+
+### Files to Create
+
+```
+src/linters/lazy_ignores/
+├── __init__.py                 # Empty, just exports
+├── types.py                    # IgnoreDirective, SuppressionEntry dataclasses
+└── config.py                   # LazyIgnoresConfig dataclass
+
+tests/unit/linters/lazy_ignores/
+├── __init__.py
+├── conftest.py                 # Shared fixtures
+├── test_python_ignore_detection.py
+├── test_header_parser.py
+├── test_orphaned_detection.py
+├── test_violation_messages.py
+└── test_typescript_detection.py
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Create types.py
+
+```python
+"""
+Purpose: Type definitions for lazy-ignores linter
+Scope: Data structures for ignore directives and suppression entries
+"""
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+
+class IgnoreType(Enum):
+    """Type of linting ignore directive."""
+    NOQA = "noqa"
+    TYPE_IGNORE = "type:ignore"
+    PYLINT_DISABLE = "pylint:disable"
+    NOSEC = "nosec"
+    TS_IGNORE = "ts-ignore"
+    TS_NOCHECK = "ts-nocheck"
+    TS_EXPECT_ERROR = "ts-expect-error"
+    ESLINT_DISABLE = "eslint-disable"
+
+
+@dataclass(frozen=True)
+class IgnoreDirective:
+    """Represents a linting ignore found in code."""
+    ignore_type: IgnoreType
+    rule_ids: tuple[str, ...]  # Can have multiple: noqa: PLR0912, PLR0915
+    line: int
+    column: int
+    raw_text: str  # Original comment text
+    file_path: Path
+
+
+@dataclass(frozen=True)
+class SuppressionEntry:
+    """Represents a suppression declared in file header."""
+    rule_id: str  # Normalized rule ID
+    justification: str
+    raw_text: str  # Original header line
+```
+
+#### Step 2: Create config.py
+
+```python
+"""
+Purpose: Configuration for lazy-ignores linter
+Scope: All configurable options
+"""
+from dataclasses import dataclass, field
+
+
+@dataclass
+class LazyIgnoresConfig:
+    """Configuration for the lazy-ignores linter."""
+    # Pattern detection toggles
+    check_noqa: bool = True
+    check_type_ignore: bool = True
+    check_pylint_disable: bool = True
+    check_nosec: bool = True
+    check_ts_ignore: bool = True
+    check_eslint_disable: bool = True
+    check_test_skips: bool = True
+
+    # Orphaned detection
+    check_orphaned: bool = True  # Header entries without matching ignores
+
+    # File patterns to ignore
+    ignore_patterns: list[str] = field(default_factory=lambda: [
+        "tests/**",  # Don't enforce in test files by default
+        "**/__pycache__/**",
+    ])
+
+    @classmethod
+    def from_dict(cls, config_dict: dict) -> "LazyIgnoresConfig":
+        """Create config from dictionary."""
+        return cls(
+            check_noqa=config_dict.get("check_noqa", True),
+            check_type_ignore=config_dict.get("check_type_ignore", True),
+            check_pylint_disable=config_dict.get("check_pylint_disable", True),
+            check_nosec=config_dict.get("check_nosec", True),
+            check_ts_ignore=config_dict.get("check_ts_ignore", True),
+            check_eslint_disable=config_dict.get("check_eslint_disable", True),
+            check_test_skips=config_dict.get("check_test_skips", True),
+            check_orphaned=config_dict.get("check_orphaned", True),
+            ignore_patterns=config_dict.get("ignore_patterns", []),
+        )
+```
+
+#### Step 3: Create test files with failing tests
+
+**tests/unit/linters/lazy_ignores/test_python_ignore_detection.py**:
+
+```python
+"""Tests for Python ignore pattern detection."""
+import pytest
+from src.linters.lazy_ignores.python_analyzer import PythonIgnoreDetector
+
+
+class TestNoqaDetection:
+    """Tests for # noqa pattern detection."""
+
+    def test_detects_bare_noqa(self) -> None:
+        """Detects # noqa without rule IDs."""
+        code = "x = 1  # noqa"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert directives[0].rule_ids == ()
+
+    def test_detects_noqa_with_single_rule(self) -> None:
+        """Detects # noqa: PLR0912."""
+        code = "def complex():  # noqa: PLR0912"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert "PLR0912" in directives[0].rule_ids
+
+    def test_detects_noqa_with_multiple_rules(self) -> None:
+        """Detects # noqa: PLR0912, PLR0915."""
+        code = "def complex():  # noqa: PLR0912, PLR0915"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert "PLR0912" in directives[0].rule_ids
+        assert "PLR0915" in directives[0].rule_ids
+
+
+class TestTypeIgnoreDetection:
+    """Tests for # type: ignore detection."""
+
+    def test_detects_bare_type_ignore(self) -> None:
+        """Detects # type: ignore."""
+        code = "x: int = 'string'  # type: ignore"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+
+    def test_detects_type_ignore_with_code(self) -> None:
+        """Detects # type: ignore[arg-type]."""
+        code = "foo(x)  # type: ignore[arg-type]"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert "arg-type" in directives[0].rule_ids
+
+
+class TestPylintDisableDetection:
+    """Tests for # pylint: disable detection."""
+
+    def test_detects_pylint_disable(self) -> None:
+        """Detects # pylint: disable=no-member."""
+        code = "obj.method()  # pylint: disable=no-member"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert "no-member" in directives[0].rule_ids
+
+
+class TestNosecDetection:
+    """Tests for # nosec detection."""
+
+    def test_detects_nosec_with_rule(self) -> None:
+        """Detects # nosec B602."""
+        code = "subprocess.run(cmd, shell=True)  # nosec B602"
+        detector = PythonIgnoreDetector()
+        directives = detector.find_ignores(code)
+        assert len(directives) == 1
+        assert "B602" in directives[0].rule_ids
+```
+
+**tests/unit/linters/lazy_ignores/test_header_parser.py**:
+
+```python
+"""Tests for header Suppressions section parsing."""
+import pytest
+from src.linters.lazy_ignores.header_parser import SuppressionsParser
+
+
+class TestSuppressionsExtraction:
+    """Tests for extracting Suppressions section from headers."""
+
+    def test_parses_single_suppression(self) -> None:
+        """Parses a single suppression entry."""
+        header = '''"""
+Purpose: Test file
+
+Suppressions:
+    PLR0912: Complex branching required for state machine
+"""'''
+        parser = SuppressionsParser()
+        entries = parser.parse(header)
+        assert len(entries) == 1
+        assert entries["PLR0912"] == "Complex branching required for state machine"
+
+    def test_parses_multiple_suppressions(self) -> None:
+        """Parses multiple suppression entries."""
+        header = '''"""
+Purpose: Test file
+
+Suppressions:
+    PLR0912: State machine complexity
+    type:ignore[arg-type]: Pydantic validation
+    nosec B602: Trusted subprocess call
+"""'''
+        parser = SuppressionsParser()
+        entries = parser.parse(header)
+        assert len(entries) == 3
+        assert "PLR0912" in entries
+        assert "type:ignore[arg-type]" in entries
+        assert "nosec B602" in entries
+
+    def test_returns_empty_when_no_suppressions(self) -> None:
+        """Returns empty dict when no Suppressions section."""
+        header = '''"""
+Purpose: Test file
+Scope: Testing
+"""'''
+        parser = SuppressionsParser()
+        entries = parser.parse(header)
+        assert entries == {}
+
+
+class TestRuleIdNormalization:
+    """Tests for rule ID normalization."""
+
+    def test_normalizes_case(self) -> None:
+        """Normalizes rule ID case for matching."""
+        parser = SuppressionsParser()
+        # These should all match the same rule
+        assert parser.normalize_rule_id("PLR0912") == parser.normalize_rule_id("plr0912")
+
+    def test_preserves_type_ignore_brackets(self) -> None:
+        """Preserves type:ignore[code] format."""
+        parser = SuppressionsParser()
+        normalized = parser.normalize_rule_id("type:ignore[arg-type]")
+        assert "arg-type" in normalized
+```
+
+**tests/unit/linters/lazy_ignores/test_orphaned_detection.py**:
+
+```python
+"""Tests for orphaned suppression detection."""
+import pytest
+from src.linters.lazy_ignores.linter import LazyIgnoresRule
+
+
+class TestOrphanedDetection:
+    """Tests for detecting orphaned header entries."""
+
+    def test_detects_orphaned_suppression(self) -> None:
+        """Header declares PLR0912 but no such ignore in code."""
+        code = '''"""
+Purpose: Test
+
+Suppressions:
+    PLR0912: Some justification
+"""
+
+def simple_function():
+    return 1
+'''
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 1
+
+    def test_no_orphaned_when_ignore_exists(self) -> None:
+        """No orphaned violation when ignore actually exists."""
+        code = '''"""
+Purpose: Test
+
+Suppressions:
+    PLR0912: State machine complexity
+"""
+
+def complex():  # noqa: PLR0912
+    # ... complex code ...
+    pass
+'''
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 0
+```
+
+**tests/unit/linters/lazy_ignores/test_violation_messages.py**:
+
+```python
+"""Tests for violation message formatting."""
+import pytest
+from src.linters.lazy_ignores.violation_builder import build_unjustified_violation
+
+
+class TestAgentGuidance:
+    """Tests for AI agent guidance in violation messages."""
+
+    def test_violation_includes_header_instruction(self) -> None:
+        """Error message tells agent to add header entry."""
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert "Suppressions:" in violation.suggestion
+        assert "PLR0912" in violation.suggestion
+
+    def test_violation_requires_human_approval(self) -> None:
+        """Error message emphasizes human approval requirement."""
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert "human" in violation.suggestion.lower()
+        assert "approval" in violation.suggestion.lower() or "permission" in violation.suggestion.lower()
+```
+
+### Success Criteria
+
+- [ ] All test files created
+- [ ] Tests fail with ImportError or NotImplementedError (not syntax errors)
+- [ ] types.py has IgnoreDirective and SuppressionEntry dataclasses
+- [ ] config.py has LazyIgnoresConfig with all options
+- [ ] `pytest tests/unit/linters/lazy_ignores/ -v` runs (tests fail but no crashes)
+
+### Testing
+
+```bash
+# Should fail with import/not-implemented errors
+pytest tests/unit/linters/lazy_ignores/ -v --tb=short
+```
+
+---
+
+## PR2: Python Ignore Detection
+
+**Goal**: Implement Python ignore pattern detection to pass tests from PR1
+
+**Scope**: Detect noqa, type:ignore, pylint:disable, nosec patterns
+
+### Files to Create
+
+```
+src/linters/lazy_ignores/
+├── ignore_detector.py      # Base detector interface
+└── python_analyzer.py      # Python-specific detection
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Create ignore_detector.py (base interface)
+
+```python
+"""
+Purpose: Base interface for ignore directive detection
+Scope: Abstract base for language-specific analyzers
+"""
+from abc import ABC, abstractmethod
+from src.linters.lazy_ignores.types import IgnoreDirective
+
+
+class BaseIgnoreDetector(ABC):
+    """Abstract base for ignore directive detectors."""
+
+    @abstractmethod
+    def find_ignores(self, code: str) -> list[IgnoreDirective]:
+        """Find all ignore directives in the given code."""
+```
+
+#### Step 2: Create python_analyzer.py
+
+```python
+"""
+Purpose: Detect Python linting ignore directives
+Scope: noqa, type:ignore, pylint:disable, nosec patterns
+"""
+import re
+from pathlib import Path
+from src.linters.lazy_ignores.ignore_detector import BaseIgnoreDetector
+from src.linters.lazy_ignores.types import IgnoreDirective, IgnoreType
+
+
+class PythonIgnoreDetector(BaseIgnoreDetector):
+    """Detects Python linting ignore directives."""
+
+    # Regex patterns for each ignore type
+    PATTERNS = {
+        IgnoreType.NOQA: re.compile(
+            r"#\s*noqa(?::\s*([A-Z0-9,\s]+))?",
+            re.IGNORECASE
+        ),
+        IgnoreType.TYPE_IGNORE: re.compile(
+            r"#\s*type:\s*ignore(?:\[([^\]]+)\])?"
+        ),
+        IgnoreType.PYLINT_DISABLE: re.compile(
+            r"#\s*pylint:\s*disable=([a-z0-9\-,]+)",
+            re.IGNORECASE
+        ),
+        IgnoreType.NOSEC: re.compile(
+            r"#\s*nosec(?:\s+([A-Z0-9]+))?",
+            re.IGNORECASE
+        ),
+    }
+
+    def find_ignores(self, code: str, file_path: Path | None = None) -> list[IgnoreDirective]:
+        """Find all Python ignore directives in code."""
+        directives: list[IgnoreDirective] = []
+
+        for line_num, line in enumerate(code.splitlines(), start=1):
+            for ignore_type, pattern in self.PATTERNS.items():
+                match = pattern.search(line)
+                if match:
+                    rule_ids = self._extract_rule_ids(match, ignore_type)
+                    directives.append(IgnoreDirective(
+                        ignore_type=ignore_type,
+                        rule_ids=tuple(rule_ids),
+                        line=line_num,
+                        column=match.start(),
+                        raw_text=match.group(0),
+                        file_path=file_path or Path("unknown"),
+                    ))
+
+        return directives
+
+    def _extract_rule_ids(self, match: re.Match, ignore_type: IgnoreType) -> list[str]:
+        """Extract rule IDs from regex match."""
+        group = match.group(1)
+        if not group:
+            return []
+
+        # Split on comma and clean up
+        ids = [r.strip() for r in group.split(",")]
+        return [r for r in ids if r]
+```
+
+### Success Criteria
+
+- [ ] All tests in test_python_ignore_detection.py pass
+- [ ] Handles edge cases (whitespace, case sensitivity)
+- [ ] Returns correct line/column positions
+
+---
+
+## PR3: Header Suppressions Parser
+
+**Goal**: Parse Suppressions: section from file headers
+
+**Scope**: Extract and normalize suppression entries from Python and TypeScript headers
+
+### Files to Create
+
+```
+src/linters/lazy_ignores/
+└── header_parser.py        # Suppressions section parser
+```
+
+### Step-by-Step Implementation
+
+#### Step 1: Create header_parser.py
+
+```python
+"""
+Purpose: Parse Suppressions section from file headers
+Scope: Python docstrings and TypeScript JSDoc comments
+"""
+import re
+from src.linters.lazy_ignores.types import SuppressionEntry
+
+
+class SuppressionsParser:
+    """Parses Suppressions section from file headers."""
+
+    # Pattern to find Suppressions section
+    SUPPRESSIONS_SECTION = re.compile(
+        r"Suppressions:\s*\n((?:\s+\S+:.*\n?)+)",
+        re.MULTILINE
+    )
+
+    # Pattern to parse individual entries
+    ENTRY_PATTERN = re.compile(
+        r"^\s+([^:]+):\s*(.+)$",
+        re.MULTILINE
+    )
+
+    def parse(self, header: str) -> dict[str, str]:
+        """Parse Suppressions section, return rule_id -> justification mapping."""
+        section_match = self.SUPPRESSIONS_SECTION.search(header)
+        if not section_match:
+            return {}
+
+        entries: dict[str, str] = {}
+        section_content = section_match.group(1)
+
+        for match in self.ENTRY_PATTERN.finditer(section_content):
+            rule_id = self.normalize_rule_id(match.group(1).strip())
+            justification = match.group(2).strip()
+            entries[rule_id] = justification
+
+        return entries
+
+    def normalize_rule_id(self, rule_id: str) -> str:
+        """Normalize rule ID for matching."""
+        # Lowercase for case-insensitive matching
+        # But preserve structure like type:ignore[arg-type]
+        return rule_id.lower()
+
+    def extract_header(self, code: str, language: str = "python") -> str:
+        """Extract the header section from code."""
+        if language == "python":
+            return self._extract_python_header(code)
+        elif language in ("typescript", "javascript"):
+            return self._extract_ts_header(code)
+        return ""
+
+    def _extract_python_header(self, code: str) -> str:
+        """Extract Python docstring header."""
+        # Match triple-quoted docstring at start of file
+        match = re.match(r'^"""(.*?)"""', code, re.DOTALL)
+        if match:
+            return match.group(0)
+        match = re.match(r"^'''(.*?)'''", code, re.DOTALL)
+        if match:
+            return match.group(0)
+        return ""
+
+    def _extract_ts_header(self, code: str) -> str:
+        """Extract TypeScript/JavaScript JSDoc header."""
+        match = re.match(r"^/\*\*(.*?)\*/", code, re.DOTALL)
+        if match:
+            return match.group(0)
+        return ""
+```
+
+### Success Criteria
+
+- [ ] All tests in test_header_parser.py pass
+- [ ] Correctly extracts Python docstring headers
+- [ ] Correctly extracts TypeScript JSDoc headers
+- [ ] Normalizes rule IDs for matching
+
+---
+
+## PR4: TypeScript/JavaScript Detection
+
+**Goal**: Detect TypeScript and JavaScript ignore patterns
+
+**Scope**: @ts-ignore, @ts-nocheck, @ts-expect-error, eslint-disable patterns
+
+### Files to Create
+
+```
+src/linters/lazy_ignores/
+└── typescript_analyzer.py  # TypeScript/JavaScript detection
+
+tests/unit/linters/lazy_ignores/
+└── test_typescript_detection.py  # Tests (if not in PR1)
+```
+
+### Patterns to Detect
+
+| Pattern | Regex | Example |
+|---------|-------|---------|
+| @ts-ignore | `//\s*@ts-ignore` | `// @ts-ignore` |
+| @ts-nocheck | `//\s*@ts-nocheck` | `// @ts-nocheck` |
+| @ts-expect-error | `//\s*@ts-expect-error` | `// @ts-expect-error` |
+| eslint-disable-next-line | `//\s*eslint-disable-next-line` | `// eslint-disable-next-line` |
+| eslint-disable (block) | `/\*\s*eslint-disable` | `/* eslint-disable */` |
+
+### Success Criteria
+
+- [ ] All TypeScript pattern tests pass
+- [ ] Handles both single-line (//) and block (/* */) comments
+- [ ] Correctly identifies line numbers
+
+---
+
+## PR5: Test Skip Detection
+
+**Goal**: Detect test skips without reasons
+
+**Scope**: pytest skips (Python), it.skip/describe.skip (JavaScript)
+
+### Files to Create
+
+```
+src/linters/lazy_ignores/
+└── test_skip_detector.py   # Test skip detection
+
+tests/unit/linters/lazy_ignores/
+└── test_test_skip_detection.py  # Tests
+```
+
+### Python Patterns
+
+```python
+# VIOLATIONS (no reason):
+@pytest.mark.skip
+@pytest.mark.skip()
+pytest.skip()
+
+# ALLOWED (has reason):
+@pytest.mark.skip(reason="...")
+@pytest.mark.skipif(condition, reason="...")
+pytest.skip("reason")
+```
+
+### JavaScript Patterns
+
+```javascript
+// VIOLATIONS (lazy skips):
+it.skip('test name', ...)
+describe.skip('suite', ...)
+test.skip('test', ...)
+
+// Note: These are always violations in JS because
+// the proper way is to remove or fix the test
+```
+
+### Success Criteria
+
+- [ ] Detects pytest skips without reason
+- [ ] Allows pytest skips with reason
+- [ ] Detects JavaScript test skips
+
+---
+
+## PR6: CLI Integration & Output Formats
+
+**Goal**: Wire everything together with CLI command and output formatting
+
+**Scope**: CLI command, text/json/sarif output, main linter class
+
+### Files to Create/Modify
+
+```
+src/linters/lazy_ignores/
+├── linter.py               # Main rule class
+└── violation_builder.py    # Agent-friendly messages
+
+src/cli/linters/
+└── code_patterns.py        # MODIFY - Add command
+```
+
+### CLI Command
+
+```bash
+thailint lazy-ignores [OPTIONS] [PATHS]...
+
+Options:
+  --format, -f [text|json|sarif]  Output format
+  --check-orphaned/--no-check-orphaned  Check for orphaned suppressions
+  --check-tests/--no-check-tests  Check test skip patterns
+  -v, --verbose  Verbose output
+```
+
+### Error Message Format
+
+```
+lazy-ignores.unjustified  src/routes.py:45:20  ERROR
+  Unjustified suppression: # noqa: PLR0912
+
+  To fix, add entry to file header Suppressions section:
+
+      Suppressions:
+          PLR0912: [Your justification here]
+
+  IMPORTANT: Suppression requires human approval. Do not add
+  without explicit permission from a human reviewer.
+```
+
+### Success Criteria
+
+- [ ] `thailint lazy-ignores src/` works
+- [ ] All three output formats work
+- [ ] Error messages include agent guidance
+- [ ] Orphaned detection works end-to-end
+
+---
+
+## PR7: Dogfooding - Internal Use
+
+**Goal**: Add lazy-ignores to thai-lint's own quality gates
+
+**Scope**: Fix own violations, add to just lint-full, update docs
+
+### Files to Modify
+
+```
+justfile                              # Add to lint-full
+.ai/docs/FILE_HEADER_STANDARDS.md     # Document Suppressions section
+AGENTS.md                             # Update with new linter
+```
+
+### Steps
+
+1. Run `thailint lazy-ignores src/` on thai-lint
+2. Add proper Suppressions sections to files with ignores
+3. Add to justfile: `just lint-lazy-ignores`
+4. Add to lint-full target
+5. Update FILE_HEADER_STANDARDS.md with Suppressions format
+6. Update AGENTS.md with new command
+
+### Success Criteria
+
+- [ ] `thailint lazy-ignores src/` passes on thai-lint
+- [ ] `just lint-full` includes lazy-ignores check
+- [ ] All existing ignores have header justifications
+
+---
+
+## PR8: Documentation & PyPI Prep
+
+**Goal**: Complete user documentation
+
+**Scope**: User guide, examples, README update
+
+### Files to Create/Modify
+
+```
+docs/linters/lazy-ignores.md           # NEW - User guide
+.ai/howtos/how-to-fix-lazy-ignores.md  # NEW - Fix guide
+README.md                              # Add to linter list
+```
+
+### Documentation Contents
+
+1. **What it detects** - Pattern list with examples
+2. **How to fix** - Step-by-step for adding Suppressions
+3. **Configuration** - All options explained
+4. **Examples** - Before/after code
+5. **CI Integration** - GitHub Actions, pre-commit
+
+### Success Criteria
+
+- [ ] User documentation complete
+- [ ] AI agent guide complete
+- [ ] README updated with new linter
+- [ ] Examples tested and working
+
+---
+
+## Implementation Guidelines
+
+### Code Standards
+- Follow existing linter patterns (see `src/linters/nesting/`)
+- Pylint score exactly 10.00/10
+- Xenon A-grade complexity (every function)
+- Full type hints, no `Any` unless absolutely necessary
+- Docstrings on all public functions (Google style)
+
+### Testing Requirements
+- TDD: Write failing tests first (PR1)
+- Target 90%+ coverage
+- Test edge cases (empty files, malformed headers)
+- Include both positive and negative test cases
+
+### Documentation Standards
+- Follow `.ai/docs/FILE_HEADER_STANDARDS.md`
+- Use atemporal language (no "currently", "now")
+- Include code examples
+
+---
+
+## Success Metrics
+
+### Launch Metrics
+- [ ] All 8 PRs merged
+- [ ] 90%+ test coverage
+- [ ] Zero false positives on thai-lint codebase
+- [ ] Performance < 100ms per file
+
+### Ongoing Metrics
+- User adoption (pypi downloads)
+- False positive reports
+- Feature requests


### PR DESCRIPTION
## Summary

Adds comprehensive roadmap for a new `lazy-ignores` linter that detects unjustified linting suppressions in AI-generated code.

### Problem Statement

AI agents often add linting suppressions (`# noqa`, `# type: ignore`, etc.) as shortcuts instead of properly fixing code. This creates hidden technical debt with no audit trail.

### Proposed Solution

A linter that:
- Requires all ignores to be documented in file header `Suppressions:` section
- Enforces human approval for adding suppressions
- Detects orphaned header entries (declared but not used)
- Provides AI-agent-friendly error messages

### Roadmap Contents

| Document | Purpose |
|----------|---------|
| PROGRESS_TRACKER.md | Primary AI agent handoff, PR status dashboard |
| PR_BREAKDOWN.md | Detailed 8-PR implementation plan with TDD |
| AI_CONTEXT.md | Architecture, design decisions, patterns |

### 8-PR Breakdown

1. **PR1**: Core infrastructure & failing tests (TDD)
2. **PR2**: Python ignore detection (noqa, type:ignore, pylint, nosec)
3. **PR3**: Header Suppressions parser
4. **PR4**: TypeScript/JavaScript detection (@ts-ignore, eslint-disable)
5. **PR5**: Test skip detection (pytest.mark.skip, it.skip)
6. **PR6**: CLI integration & output formats
7. **PR7**: Dogfooding - use on thai-lint itself
8. **PR8**: Documentation & PyPI prep

### Based on Survey of Real Projects

Surveyed safeshell, durable-code-test, tubebuddy, and tb-automation-py to identify common lazy patterns:
- Complexity ignores (PLR0912/PLR0915) without justification
- TODOs acknowledging risky type ignores
- Test skips without reasons

## Test plan

- [x] Roadmap follows template structure
- [x] All three required documents present
- [x] PR breakdown is actionable and TDD-focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)