### PR TITLE
feat(lazy-ignores): Implement LazyIgnoresRule and CLI integration (PR6)

### DIFF
--- a/.roadmap/in-progress/lazy-ignores/PROGRESS_TRACKER.md
+++ b/.roadmap/in-progress/lazy-ignores/PROGRESS_TRACKER.md
@@ -28,8 +28,8 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 
 ## Current Status
 
-**Current PR**: PR2 - Python Ignore Detection - READY TO START
-**Infrastructure State**: PR1 complete - PythonIgnoreDetector and SuppressionsParser implemented
+**Current PR**: PR6 - CLI Integration & LazyIgnoresRule - COMPLETE
+**Infrastructure State**: PR1-3, PR6 complete - Full lazy-ignores linter working with CLI
 **Feature Target**: Production-ready linter with full test coverage, integrated into thai-lint quality gates
 
 ---
@@ -63,31 +63,31 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 
 ---
 
-### START HERE: PR6 - CLI Integration & LazyIgnoresRule
+### PR6 - CLI Integration & LazyIgnoresRule - COMPLETE
 
 **Quick Summary**: Wire up the LazyIgnoresRule class with CLI integration.
 
-**Prerequisites**:
+**Completed**:
 - [x] PythonIgnoreDetector implemented
 - [x] SuppressionsParser implemented
+- [x] Created `src/linters/lazy_ignores/linter.py` with LazyIgnoresRule class
+- [x] Created `src/linters/lazy_ignores/violation_builder.py` for agent guidance messages
+- [x] Created `src/linters/lazy_ignores/matcher.py` for ignore-suppression matching
+- [x] Registered CLI command in `src/cli/linters/code_patterns.py`
+- [x] Updated tests: test_orphaned_detection.py, test_violation_messages.py
+- [x] Removed skip markers from passing tests (21 tests now passing)
+- [x] All quality gates pass (ruff, pylint, xenon, SRP)
 
-**Remaining**:
-- [ ] Create `src/linters/lazy_ignores/linter.py` with LazyIgnoresRule class
-- [ ] Create `src/linters/lazy_ignores/violation_builder.py` for agent guidance messages
-- [ ] Register CLI command in `src/cli/linters/code_patterns.py`
-- [ ] Update tests: test_orphaned_detection.py, test_violation_messages.py
-- [ ] Remove skip markers from passing tests
-
-**Detailed Steps**: See PR_BREAKDOWN.md → PR6 section
+**Next PR**: PR4 (TypeScript Detection) or PR7 (Dogfooding)
 
 ---
 
 ## Overall Progress
 
-**Total Completion**: 38% (PR1-3 complete, 3/8 PRs fully completed)
+**Total Completion**: 50% (PR1-3, PR6 complete, 4/8 PRs fully completed)
 
 ```
-[████░░░░░░] 38% Complete
+[█████░░░░░] 50% Complete
 ```
 
 ---
@@ -101,7 +101,7 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 | PR3 | Header Suppressions Parser | 🟢 Complete | 100% | Medium | P0 | SuppressionsParser implemented |
 | PR4 | TypeScript/JavaScript Detection | 🔴 Not Started | 0% | Medium | P1 | @ts-ignore, eslint-disable patterns |
 | PR5 | Test Skip Detection | 🔴 Not Started | 0% | Low | P1 | pytest.mark.skip, it.skip() |
-| PR6 | CLI Integration & Output Formats | 🔴 Not Started | 0% | Medium | P0 | Wire up CLI, text/json/sarif output |
+| PR6 | CLI Integration & Output Formats | 🟢 Complete | 100% | Medium | P0 | LazyIgnoresRule + CLI + 21 tests passing |
 | PR7 | Dogfooding - Internal Use | 🔴 Not Started | 0% | Low | P1 | Add to just lint-full, fix own violations |
 | PR8 | Documentation & PyPI Prep | 🔴 Not Started | 0% | Low | P2 | README, examples, user docs |
 

--- a/src/cli/linters/code_patterns.py
+++ b/src/cli/linters/code_patterns.py
@@ -1,17 +1,17 @@
 """
-Purpose: CLI commands for code pattern linters (print-statements, method-property, stateless-class)
+Purpose: CLI commands for code pattern linters (print-statements, method-property, stateless-class, lazy-ignores)
 
 Scope: Commands that detect code patterns and anti-patterns in Python code
 
 Overview: Provides CLI commands for code pattern linting: print-statements detects print() and
     console.log calls that should use proper logging, method-property finds methods that should be
-    @property decorators, and stateless-class detects classes without state that should be module
-    functions. Each command supports standard options (config, format, recursive) and integrates
-    with the orchestrator for execution.
+    @property decorators, stateless-class detects classes without state that should be module
+    functions, and lazy-ignores detects unjustified linting suppressions. Each command supports
+    standard options (config, format, recursive) and integrates with the orchestrator for execution.
 
 Dependencies: click for CLI framework, src.cli.main for CLI group, src.cli.utils for shared utilities
 
-Exports: print_statements command, method_property command, stateless_class command
+Exports: print_statements command, method_property command, stateless_class command, lazy_ignores command
 
 Interfaces: Click CLI commands registered to main CLI group
 
@@ -370,3 +370,108 @@ def _execute_stateless_class_lint(  # pylint: disable=too-many-arguments,too-man
 
     format_violations(stateless_class_violations, format)
     sys.exit(1 if stateless_class_violations else 0)
+
+
+# =============================================================================
+# Lazy Ignores Command
+# =============================================================================
+
+
+def _setup_lazy_ignores_orchestrator(
+    path_objs: list[Path], config_file: str | None, verbose: bool, project_root: Path | None = None
+) -> "Orchestrator":
+    """Set up orchestrator for lazy-ignores command."""
+    return setup_base_orchestrator(path_objs, config_file, verbose, project_root)
+
+
+def _run_lazy_ignores_lint(
+    orchestrator: "Orchestrator", path_objs: list[Path], recursive: bool
+) -> list[Violation]:
+    """Execute lazy-ignores lint on files or directories."""
+    all_violations = execute_linting_on_paths(orchestrator, path_objs, recursive)
+    return [v for v in all_violations if v.rule_id.startswith("lazy-ignores")]
+
+
+@cli.command("lazy-ignores")
+@click.argument("paths", nargs=-1, type=click.Path())
+@click.option("--config", "-c", "config_file", type=click.Path(), help="Path to config file")
+@format_option
+@click.option("--recursive/--no-recursive", default=True, help="Scan directories recursively")
+@click.pass_context
+def lazy_ignores(
+    ctx: click.Context,
+    paths: tuple[str, ...],
+    config_file: str | None,
+    format: str,
+    recursive: bool,
+) -> None:
+    """Check for unjustified linting suppressions.
+
+    Detects ignore directives (noqa, type:ignore, pylint:disable, nosec) that lack
+    corresponding entries in the file header's Suppressions section. Enforces a
+    header-based suppression model requiring human approval for all linting bypasses.
+
+    PATHS: Files or directories to lint (defaults to current directory if none provided)
+
+    Examples:
+
+        \b
+        # Check current directory (all files recursively)
+        thai-lint lazy-ignores
+
+        \b
+        # Check specific directory
+        thai-lint lazy-ignores src/
+
+        \b
+        # Check single file
+        thai-lint lazy-ignores src/routes.py
+
+        \b
+        # Check multiple files
+        thai-lint lazy-ignores src/routes.py src/utils.py
+
+        \b
+        # Get JSON output
+        thai-lint lazy-ignores --format json .
+
+        \b
+        # Get SARIF output for CI/CD integration
+        thai-lint lazy-ignores --format sarif src/
+
+        \b
+        # Use custom config file
+        thai-lint lazy-ignores --config .thailint.yaml src/
+    """
+    verbose: bool = ctx.obj.get("verbose", False)
+    project_root = get_project_root_from_context(ctx)
+
+    if not paths:
+        paths = (".",)
+
+    path_objs = [Path(p) for p in paths]
+
+    try:
+        _execute_lazy_ignores_lint(path_objs, config_file, format, recursive, verbose, project_root)
+    except Exception as e:
+        handle_linting_error(e, verbose)
+
+
+def _execute_lazy_ignores_lint(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    path_objs: list[Path],
+    config_file: str | None,
+    format: str,
+    recursive: bool,
+    verbose: bool,
+    project_root: Path | None = None,
+) -> NoReturn:
+    """Execute lazy-ignores lint."""
+    validate_paths_exist(path_objs)
+    orchestrator = _setup_lazy_ignores_orchestrator(path_objs, config_file, verbose, project_root)
+    lazy_ignores_violations = _run_lazy_ignores_lint(orchestrator, path_objs, recursive)
+
+    if verbose:
+        logger.info(f"Found {len(lazy_ignores_violations)} lazy-ignores violation(s)")
+
+    format_violations(lazy_ignores_violations, format)
+    sys.exit(1 if lazy_ignores_violations else 0)

--- a/src/linters/lazy_ignores/__init__.py
+++ b/src/linters/lazy_ignores/__init__.py
@@ -21,8 +21,10 @@ Implementation: Enum and dataclass definitions for ignore directive representati
 
 from .config import LazyIgnoresConfig
 from .header_parser import SuppressionsParser
+from .linter import LazyIgnoresRule
 from .python_analyzer import PythonIgnoreDetector
 from .types import IgnoreDirective, IgnoreType, SuppressionEntry
+from .violation_builder import build_orphaned_violation, build_unjustified_violation
 
 __all__ = [
     "IgnoreType",
@@ -31,4 +33,7 @@ __all__ = [
     "LazyIgnoresConfig",
     "PythonIgnoreDetector",
     "SuppressionsParser",
+    "LazyIgnoresRule",
+    "build_unjustified_violation",
+    "build_orphaned_violation",
 ]

--- a/src/linters/lazy_ignores/linter.py
+++ b/src/linters/lazy_ignores/linter.py
@@ -1,0 +1,145 @@
+"""
+Purpose: Main LazyIgnoresRule class for detecting unjustified linting suppressions
+
+Scope: Orchestration of ignore detection and header suppression validation
+
+Overview: Provides LazyIgnoresRule that cross-references linting ignore directives found
+    in code (noqa, type:ignore, pylint:disable, nosec) with Suppressions entries declared
+    in file headers. Detects two types of violations: unjustified ignores (ignore directive
+    without header declaration) and orphaned suppressions (header declaration without
+    matching ignore in code). Enforces the header-based suppression model requiring human
+    approval for all linting bypasses.
+
+Dependencies: PythonIgnoreDetector, SuppressionsParser, IgnoreSuppressionMatcher, violation_builder
+
+Exports: LazyIgnoresRule
+
+Interfaces: check(context: BaseLintContext) -> list[Violation]
+
+Implementation: Delegation to matcher for cross-reference logic, violation builder for messages
+"""
+
+from pathlib import Path
+
+from src.core.base import BaseLintContext, BaseLintRule
+from src.core.constants import Language
+from src.core.types import Violation
+
+from .header_parser import SuppressionsParser
+from .matcher import IgnoreSuppressionMatcher
+from .python_analyzer import PythonIgnoreDetector
+from .types import IgnoreDirective
+from .violation_builder import build_orphaned_violation, build_unjustified_violation
+
+
+class LazyIgnoresRule(BaseLintRule):
+    """Detects unjustified linting suppressions and orphaned header entries."""
+
+    def __init__(self) -> None:
+        """Initialize the lazy ignores rule with detection components."""
+        self._python_detector = PythonIgnoreDetector()
+        self._suppression_parser = SuppressionsParser()
+        self._matcher = IgnoreSuppressionMatcher(self._suppression_parser)
+
+    @property
+    def rule_id(self) -> str:
+        """Unique identifier for this rule."""
+        return "lazy-ignores"
+
+    @property
+    def rule_name(self) -> str:
+        """Human-readable name for this rule."""
+        return "Lazy Ignores"
+
+    @property
+    def description(self) -> str:
+        """Description of what this rule checks."""
+        return (
+            "Detects linting suppressions (noqa, type:ignore, pylint:disable, nosec) "
+            "without corresponding entries in the file header's Suppressions section."
+        )
+
+    def check(self, context: BaseLintContext) -> list[Violation]:
+        """Check for violations in the given context.
+
+        Args:
+            context: The lint context containing file information.
+
+        Returns:
+            List of violations for unjustified and orphaned suppressions.
+        """
+        if context.language != Language.PYTHON:
+            return []
+
+        if not context.file_content:
+            return []
+
+        file_path = str(context.file_path) if context.file_path else "unknown"
+        return self.check_content(context.file_content, file_path)
+
+    def check_content(self, code: str, file_path: str) -> list[Violation]:
+        """Check code for unjustified ignores and orphaned suppressions.
+
+        Args:
+            code: Source code content to analyze.
+            file_path: Path to the file being analyzed.
+
+        Returns:
+            List of violations for unjustified and orphaned suppressions.
+        """
+        # Extract and parse header suppressions
+        header = self._suppression_parser.extract_header(code, "python")
+        suppressions = self._suppression_parser.parse(header)
+
+        # Find all ignore directives in code
+        ignores = self._python_detector.find_ignores(code, Path(file_path))
+
+        # Build set of normalized rule IDs used in code
+        used_rule_ids = self._matcher.collect_used_rule_ids(ignores)
+
+        # Find violations
+        violations: list[Violation] = []
+        violations.extend(self._find_unjustified(ignores, suppressions, file_path))
+        violations.extend(self._find_orphaned(suppressions, used_rule_ids, file_path))
+
+        return violations
+
+    def _find_unjustified(
+        self, ignores: list[IgnoreDirective], suppressions: dict[str, str], file_path: str
+    ) -> list[Violation]:
+        """Find ignore directives without matching header suppressions."""
+        violations: list[Violation] = []
+
+        for ignore in ignores:
+            unjustified = self._matcher.find_unjustified_rule_ids(ignore, suppressions)
+            if unjustified:
+                violations.append(
+                    build_unjustified_violation(
+                        file_path=file_path,
+                        line=ignore.line,
+                        column=ignore.column,
+                        rule_id=", ".join(unjustified),
+                        raw_text=ignore.raw_text,
+                    )
+                )
+
+        return violations
+
+    def _find_orphaned(
+        self, suppressions: dict[str, str], used_rule_ids: set[str], file_path: str
+    ) -> list[Violation]:
+        """Find header suppressions without matching code ignores."""
+        violations: list[Violation] = []
+        orphaned = self._matcher.find_orphaned_rule_ids(suppressions, used_rule_ids)
+
+        for rule_id, justification in orphaned:
+            violations.append(
+                build_orphaned_violation(
+                    file_path=file_path,
+                    header_line=1,  # Header entries are at file start
+                    rule_id=rule_id,
+                    justification=justification,
+                )
+            )
+
+        return violations

--- a/src/linters/lazy_ignores/matcher.py
+++ b/src/linters/lazy_ignores/matcher.py
@@ -1,0 +1,158 @@
+"""
+Purpose: Cross-reference matcher for lazy-ignores linter
+
+Scope: Matching ignore directives with header suppressions
+
+Overview: Provides IgnoreSuppressionMatcher class that cross-references linting ignore
+    directives found in code with Suppressions entries declared in file headers. Handles
+    case-insensitive rule ID normalization and special patterns like type:ignore[code].
+    Identifies unjustified ignores (code ignores without header entries) and orphaned
+    suppressions (header entries without matching code ignores).
+
+Dependencies: SuppressionsParser for normalization, types for IgnoreDirective and IgnoreType
+
+Exports: IgnoreSuppressionMatcher
+
+Interfaces: find_unjustified(), find_orphaned()
+
+Implementation: Set-based matching with rule ID normalization for case-insensitive comparison
+"""
+
+from .header_parser import SuppressionsParser
+from .types import IgnoreDirective, IgnoreType
+
+
+class IgnoreSuppressionMatcher:
+    """Matches ignore directives with header suppressions."""
+
+    def __init__(self, parser: SuppressionsParser) -> None:
+        """Initialize the matcher.
+
+        Args:
+            parser: SuppressionsParser for rule ID normalization.
+        """
+        self._parser = parser
+
+    def collect_used_rule_ids(self, ignores: list[IgnoreDirective]) -> set[str]:
+        """Collect all normalized rule IDs used in ignore directives.
+
+        Args:
+            ignores: List of ignore directives from code.
+
+        Returns:
+            Set of normalized rule IDs that have ignore directives.
+        """
+        used: set[str] = set()
+        for ignore in ignores:
+            used.update(self._get_matchable_rule_ids(ignore))
+        return used
+
+    def _get_matchable_rule_ids(self, ignore: IgnoreDirective) -> list[str]:
+        """Get normalized rule IDs for matching, handling special formats.
+
+        For type:ignore directives, generates both the raw rule_id and
+        the full type:ignore[rule_id] format for header matching.
+
+        Args:
+            ignore: The ignore directive to extract rule IDs from.
+
+        Returns:
+            List of normalized rule IDs for matching.
+        """
+        if not ignore.rule_ids:
+            # Bare ignores (no rule IDs) are tracked by their type
+            return [self._normalize(ignore.ignore_type.value)]
+
+        ids: list[str] = []
+        for rule_id in ignore.rule_ids:
+            normalized = self._normalize(rule_id)
+            ids.append(normalized)
+
+            # For type:ignore, also add the full format for header matching
+            if ignore.ignore_type == IgnoreType.TYPE_IGNORE:
+                full_format = f"type:ignore[{normalized}]"
+                ids.append(full_format)
+
+        return ids
+
+    def find_unjustified_rule_ids(
+        self, ignore: IgnoreDirective, suppressions: dict[str, str]
+    ) -> list[str]:
+        """Find which rule IDs in an ignore are not justified.
+
+        Args:
+            ignore: The ignore directive to check.
+            suppressions: Dict of normalized rule IDs to justifications.
+
+        Returns:
+            List of unjustified rule IDs (original case preserved).
+        """
+        if not ignore.rule_ids:
+            # Bare ignore (e.g., # noqa without rules) - check by type
+            type_key = self._normalize(ignore.ignore_type.value)
+            if type_key not in suppressions:
+                return [ignore.ignore_type.value]
+            return []
+
+        # Check each specific rule ID
+        unjustified: list[str] = []
+        for rule_id in ignore.rule_ids:
+            if not self._is_rule_justified(ignore, rule_id, suppressions):
+                unjustified.append(rule_id)
+        return unjustified
+
+    def _is_rule_justified(
+        self, ignore: IgnoreDirective, rule_id: str, suppressions: dict[str, str]
+    ) -> bool:
+        """Check if a specific rule ID is justified in suppressions.
+
+        Args:
+            ignore: The ignore directive containing this rule.
+            rule_id: The rule ID to check.
+            suppressions: Dict of normalized rule IDs to justifications.
+
+        Returns:
+            True if the rule has a matching suppression entry.
+        """
+        normalized = self._normalize(rule_id)
+
+        # Direct match
+        if normalized in suppressions:
+            return True
+
+        # For type:ignore, also check the full format
+        if ignore.ignore_type == IgnoreType.TYPE_IGNORE:
+            full_format = f"type:ignore[{normalized}]"
+            if full_format in suppressions:
+                return True
+
+        return False
+
+    def find_orphaned_rule_ids(
+        self, suppressions: dict[str, str], used_rule_ids: set[str]
+    ) -> list[tuple[str, str]]:
+        """Find header suppressions without matching code ignores.
+
+        Args:
+            suppressions: Dict mapping normalized rule IDs to justifications.
+            used_rule_ids: Set of normalized rule IDs used in code.
+
+        Returns:
+            List of (rule_id, justification) tuples for orphaned suppressions.
+        """
+        orphaned: list[tuple[str, str]] = []
+        for rule_id, justification in suppressions.items():
+            if rule_id not in used_rule_ids:
+                orphaned.append((rule_id.upper(), justification))
+        return orphaned
+
+    def _normalize(self, rule_id: str) -> str:
+        """Normalize a rule ID for case-insensitive matching.
+
+        Args:
+            rule_id: The rule ID to normalize.
+
+        Returns:
+            Lowercase rule ID.
+        """
+        return self._parser.normalize_rule_id(rule_id)

--- a/src/linters/lazy_ignores/violation_builder.py
+++ b/src/linters/lazy_ignores/violation_builder.py
@@ -1,0 +1,128 @@
+"""
+Purpose: Build agent-friendly violation messages for lazy-ignores linter
+
+Scope: Violation construction for unjustified ignores and orphaned header suppressions
+
+Overview: Provides functions to construct Violation objects with AI-agent-friendly error
+    messages. Messages include explicit guidance for adding Suppressions section entries to
+    file headers and emphasize the requirement for human approval before adding suppressions.
+    Designed to help AI coding assistants understand the proper workflow for handling linting
+    suppressions rather than blindly adding ignore directives.
+
+Dependencies: src.core.types for Violation dataclass
+
+Exports: build_unjustified_violation, build_orphaned_violation
+
+Interfaces: Two builder functions returning Violation objects
+
+Implementation: Template-based message construction with rule ID formatting
+"""
+
+from src.core.types import Severity, Violation
+
+
+def build_unjustified_violation(
+    file_path: str,
+    line: int,
+    column: int,
+    rule_id: str,
+    raw_text: str,
+) -> Violation:
+    """Create violation for an ignore directive without header justification.
+
+    Args:
+        file_path: Path to the file containing the violation.
+        line: Line number where the ignore was found (1-indexed).
+        column: Column number where the ignore starts (0-indexed).
+        rule_id: The rule ID(s) being suppressed (e.g., "PLR0912").
+        raw_text: The raw ignore directive text found in code.
+
+    Returns:
+        Violation object with agent-friendly guidance message.
+    """
+    message = f"Unjustified suppression found: {raw_text}"
+
+    suggestion = _build_unjustified_suggestion(rule_id)
+
+    return Violation(
+        rule_id="lazy-ignores.unjustified",
+        file_path=file_path,
+        line=line,
+        column=column,
+        message=message,
+        severity=Severity.ERROR,
+        suggestion=suggestion,
+    )
+
+
+def _build_unjustified_suggestion(rule_id: str) -> str:
+    """Build the suggestion text for unjustified violations.
+
+    Args:
+        rule_id: The rule ID(s) being suppressed.
+
+    Returns:
+        Formatted suggestion string with header instructions.
+    """
+    # Handle multiple rules (e.g., "PLR0912, PLR0915")
+    rule_ids = [r.strip() for r in rule_id.split(",")]
+
+    suppression_entries = "\n".join(f"    {rid}: [Your justification here]" for rid in rule_ids)
+
+    return f"""To fix, add an entry to the file header Suppressions section:
+
+    Suppressions:
+{suppression_entries}
+
+IMPORTANT: Adding suppressions requires human approval.
+Do not add this entry without explicit permission from a human reviewer.
+Ask first, then add if approved."""
+
+
+def build_orphaned_violation(
+    file_path: str,
+    header_line: int,
+    rule_id: str,
+    justification: str,
+) -> Violation:
+    """Create violation for a header entry without matching code ignore.
+
+    Args:
+        file_path: Path to the file containing the orphaned entry.
+        header_line: Line number of the suppression in the header (1-indexed).
+        rule_id: The orphaned rule ID from the header.
+        justification: The justification text from the header.
+
+    Returns:
+        Violation object suggesting removal of the orphaned entry.
+    """
+    message = f"Orphaned suppression in header: {rule_id}: {justification}"
+
+    suggestion = _build_orphaned_suggestion(rule_id)
+
+    return Violation(
+        rule_id="lazy-ignores.orphaned",
+        file_path=file_path,
+        line=header_line,
+        column=0,
+        message=message,
+        severity=Severity.ERROR,
+        suggestion=suggestion,
+    )
+
+
+def _build_orphaned_suggestion(rule_id: str) -> str:
+    """Build the suggestion text for orphaned violations.
+
+    Args:
+        rule_id: The orphaned rule ID.
+
+    Returns:
+        Formatted suggestion string with removal instructions.
+    """
+    return f"""This rule is declared in the Suppressions section but no matching
+ignore directive was found in the code.
+
+Either:
+1. Remove the entry for {rule_id} from the Suppressions section if the ignore was removed from code
+2. Add the ignore directive if it's missing from the code"""

--- a/tests/unit/linters/lazy_ignores/test_orphaned_detection.py
+++ b/tests/unit/linters/lazy_ignores/test_orphaned_detection.py
@@ -3,10 +3,9 @@ Purpose: Tests for orphaned suppression detection
 
 Scope: Unit tests for detecting header entries without matching ignores in code
 
-Overview: TDD test suite for orphaned suppression detection. An orphaned suppression is
+Overview: Test suite for orphaned suppression detection. An orphaned suppression is
     one that is declared in the file header's Suppressions section but has no corresponding
     ignore directive in the code. This indicates stale documentation that should be removed.
-    All tests are marked as skip pending implementation.
 
 Dependencies: pytest, src.linters.lazy_ignores
 
@@ -14,19 +13,18 @@ Exports: Test classes for orphaned detection
 
 Interfaces: pytest test discovery and execution
 
-Implementation: TDD tests marked as skip until implementation is complete
+Implementation: Unit tests validating LazyIgnoresRule orphaned detection
 """
 
-import pytest
+from src.linters.lazy_ignores import LazyIgnoresRule
 
 
 class TestOrphanedDetection:
     """Tests for detecting orphaned header entries."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_detects_orphaned_suppression(self) -> None:
         """Header declares PLR0912 but no such ignore in code."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -36,15 +34,14 @@ Suppressions:
 def simple_function():
     return 1
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 1
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 1
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_no_orphaned_when_ignore_exists(self) -> None:
         """No orphaned violation when ignore actually exists."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -55,15 +52,14 @@ def complex():  # noqa: PLR0912
     # ... complex code ...
     pass
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 0
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 0
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_detects_multiple_orphaned(self) -> None:
         """Detects multiple orphaned suppressions."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -75,19 +71,18 @@ Suppressions:
 def simple():
     return 1
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 3
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 3
 
 
 class TestPartialOrphaned:
     """Tests for partial orphaned detection."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_some_used_some_orphaned(self) -> None:
         """Detects only orphaned entries when some are used."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -98,20 +93,19 @@ Suppressions:
 def complex():  # noqa: PLR0912
     pass
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 1
-        # assert "PLR0915" in orphaned[0].message
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 1
+        assert "PLR0915" in orphaned[0].message
 
 
 class TestOrphanedWithNormalization:
     """Tests for orphaned detection with rule ID normalization."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_matches_case_insensitive(self) -> None:
         """Matches PLR0912 in header with plr0912 in code."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -121,15 +115,14 @@ Suppressions:
 def complex():  # noqa: plr0912
     pass
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 0
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 0
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_matches_type_ignore_variants(self) -> None:
         """Matches type:ignore[arg-type] variations."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -138,19 +131,18 @@ Suppressions:
 
 value = get_value()  # type: ignore[arg-type]
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert len(orphaned) == 0
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert len(orphaned) == 0
 
 
 class TestOrphanedErrorMessages:
     """Tests for orphaned violation error messages."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_error_includes_rule_id(self) -> None:
         """Error message includes the orphaned rule ID."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -160,15 +152,14 @@ Suppressions:
 def simple():
     return 1
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert "PLR0912" in orphaned[0].message
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert "PLR0912" in orphaned[0].message
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_error_suggests_removal(self) -> None:
         """Error message suggests removing the orphaned entry."""
-        _code = '''"""  # noqa: F841
+        code = '''"""
 Purpose: Test
 
 Suppressions:
@@ -178,7 +169,7 @@ Suppressions:
 def simple():
     return 1
 '''
-        # rule = LazyIgnoresRule()
-        # violations = rule.check_content(code, "test.py")
-        # orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
-        # assert "remove" in orphaned[0].suggestion.lower()
+        rule = LazyIgnoresRule()
+        violations = rule.check_content(code, "test.py")
+        orphaned = [v for v in violations if "orphaned" in v.rule_id.lower()]
+        assert "remove" in orphaned[0].suggestion.lower()

--- a/tests/unit/linters/lazy_ignores/test_violation_messages.py
+++ b/tests/unit/linters/lazy_ignores/test_violation_messages.py
@@ -3,10 +3,9 @@ Purpose: Tests for violation message formatting
 
 Scope: Unit tests for AI agent guidance and error message content
 
-Overview: TDD test suite for violation message formatting. Tests that error messages include
+Overview: Test suite for violation message formatting. Tests that error messages include
     proper guidance for AI agents including instructions to add Suppressions section entries,
-    explicit human approval requirements, and proper rule ID inclusion. All tests are marked
-    as skip pending implementation of violation builder.
+    explicit human approval requirements, and proper rule ID inclusion.
 
 Dependencies: pytest, src.linters.lazy_ignores
 
@@ -14,176 +13,180 @@ Exports: Test classes for violation message validation
 
 Interfaces: pytest test discovery and execution
 
-Implementation: TDD tests marked as skip until implementation is complete
+Implementation: Unit tests validating violation builder functions
 """
 
-import pytest
+from src.linters.lazy_ignores.violation_builder import (
+    build_orphaned_violation,
+    build_unjustified_violation,
+)
 
 
 class TestAgentGuidance:
     """Tests for AI agent guidance in violation messages."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_includes_header_instruction(self) -> None:
         """Error message tells agent to add header entry."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert "Suppressions:" in violation.suggestion
-        # assert "PLR0912" in violation.suggestion
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert "Suppressions:" in violation.suggestion
+        assert "PLR0912" in violation.suggestion
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_requires_human_approval(self) -> None:
         """Error message emphasizes human approval requirement."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert "human" in violation.suggestion.lower()
-        # assert "approval" in violation.suggestion.lower() or "permission" in violation.suggestion.lower()
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert "human" in violation.suggestion.lower()
+        assert (
+            "approval" in violation.suggestion.lower()
+            or "permission" in violation.suggestion.lower()
+        )
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_shows_example_format(self) -> None:
         """Error message shows example Suppressions entry format."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
         # Example format should show: PLR0912: [justification]
-        # assert "PLR0912:" in violation.suggestion
+        assert "PLR0912:" in violation.suggestion
 
 
 class TestViolationContent:
     """Tests for violation content and metadata."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_includes_file_path(self) -> None:
         """Violation includes correct file path."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert violation.file_path == "src/routes.py"
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert violation.file_path == "src/routes.py"
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_includes_line_number(self) -> None:
         """Violation includes correct line number."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert violation.line == 45
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert violation.line == 45
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_violation_includes_raw_ignore_text(self) -> None:
         """Violation message includes the actual ignore text found."""
-        # violation = build_unjustified_violation(
-        #     file_path="src/routes.py",
-        #     line=45,
-        #     column=20,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert "# noqa: PLR0912" in violation.message
+        violation = build_unjustified_violation(
+            file_path="src/routes.py",
+            line=45,
+            column=20,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert "# noqa: PLR0912" in violation.message
 
 
 class TestRuleIdFormatting:
     """Tests for rule ID formatting in violations."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_rule_id_follows_pattern(self) -> None:
         """Rule ID follows lazy-ignores.* pattern."""
-        # violation = build_unjustified_violation(
-        #     file_path="test.py",
-        #     line=1,
-        #     column=0,
-        #     rule_id="PLR0912",
-        #     raw_text="# noqa: PLR0912",
-        # )
-        # assert violation.rule_id.startswith("lazy-ignores.")
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert violation.rule_id.startswith("lazy-ignores.")
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_unjustified_rule_id(self) -> None:
         """Unjustified suppression uses correct rule ID."""
-        # violation = build_unjustified_violation(...)
-        # assert violation.rule_id == "lazy-ignores.unjustified"
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="PLR0912",
+            raw_text="# noqa: PLR0912",
+        )
+        assert violation.rule_id == "lazy-ignores.unjustified"
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_orphaned_rule_id(self) -> None:
         """Orphaned suppression uses correct rule ID."""
-        # violation = build_orphaned_violation(...)
-        # assert violation.rule_id == "lazy-ignores.orphaned"
+        violation = build_orphaned_violation(
+            file_path="test.py",
+            header_line=5,
+            rule_id="PLR0912",
+            justification="Old justification",
+        )
+        assert violation.rule_id == "lazy-ignores.orphaned"
 
 
 class TestMultiRuleViolations:
     """Tests for violations involving multiple rules."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_multiple_rules_in_message(self) -> None:
         """Message includes all rules when multiple are suppressed."""
-        # violation = build_unjustified_violation(
-        #     file_path="test.py",
-        #     line=1,
-        #     column=0,
-        #     rule_id="PLR0912, PLR0915",
-        #     raw_text="# noqa: PLR0912, PLR0915",
-        # )
-        # assert "PLR0912" in violation.message
-        # assert "PLR0915" in violation.message
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="PLR0912, PLR0915",
+            raw_text="# noqa: PLR0912, PLR0915",
+        )
+        assert "PLR0912" in violation.message
+        assert "PLR0915" in violation.message
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_suggestion_for_each_rule(self) -> None:
         """Suggestion includes entry format for each rule."""
-        # violation = build_unjustified_violation(
-        #     file_path="test.py",
-        #     line=1,
-        #     column=0,
-        #     rule_id="PLR0912, PLR0915",
-        #     raw_text="# noqa: PLR0912, PLR0915",
-        # )
-        # assert "PLR0912:" in violation.suggestion
-        # assert "PLR0915:" in violation.suggestion
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="PLR0912, PLR0915",
+            raw_text="# noqa: PLR0912, PLR0915",
+        )
+        assert "PLR0912:" in violation.suggestion
+        assert "PLR0915:" in violation.suggestion
 
 
 class TestThailintIgnoreViolations:
     """Tests for thai-lint ignore specific violation messages."""
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_thailint_ignore_message(self) -> None:
         """Violation message for thailint ignore directive."""
-        # violation = build_unjustified_violation(
-        #     file_path="test.py",
-        #     line=1,
-        #     column=0,
-        #     rule_id="magic-numbers",
-        #     raw_text="# thailint: ignore[magic-numbers]",
-        # )
-        # assert "magic-numbers" in violation.message
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="magic-numbers",
+            raw_text="# thailint: ignore[magic-numbers]",
+        )
+        assert "magic-numbers" in violation.message
 
-    @pytest.mark.skip(reason="TDD: Not yet implemented - lazy-ignores PR1")
     def test_thailint_ignore_file_message(self) -> None:
         """Violation message for thailint ignore-file directive."""
-        # violation = build_unjustified_violation(
-        #     file_path="test.py",
-        #     line=1,
-        #     column=0,
-        #     rule_id="magic-numbers",
-        #     raw_text="# thailint: ignore-file[magic-numbers]",
-        # )
-        # assert "ignore-file" in violation.message or "file-level" in violation.message.lower()
+        violation = build_unjustified_violation(
+            file_path="test.py",
+            line=1,
+            column=0,
+            rule_id="magic-numbers",
+            raw_text="# thailint: ignore-file[magic-numbers]",
+        )
+        assert "ignore-file" in violation.message or "file-level" in violation.message.lower()


### PR DESCRIPTION
## Summary

- Implements the core lazy-ignores linter with CLI integration
- Adds `LazyIgnoresRule` class extending `BaseLintRule` for orchestrator discovery
- Adds `IgnoreSuppressionMatcher` for cross-referencing ignores with header suppressions
- Adds `violation_builder` with agent-friendly error messages requiring human approval
- Registers `thailint lazy-ignores` CLI command
- Enables 21 tests (8 orphaned detection, 13 violation messages)

## What it detects

- **Unjustified ignores**: Code has ignore directive (`# noqa`, `# type: ignore`, `# pylint: disable`, `# nosec`) without corresponding header `Suppressions:` entry
- **Orphaned suppressions**: Header declares suppression not used anywhere in code

## Example Usage

```bash
# Check a directory
thailint lazy-ignores src/

# Check specific file
thailint lazy-ignores src/routes.py

# JSON output
thailint lazy-ignores --format json src/
```

## Example Output

```
Found 2 violation(s):

  src/linters/nesting/typescript_analyzer.py:32:17
    [ERROR] lazy-ignores.unjustified: Unjustified suppression found: # type: ignore

  src/linters/nesting/typescript_function_extractor.py:30:34
    [ERROR] lazy-ignores.unjustified: Unjustified suppression found: # pylint: disable=useless-parent-delegation
```

## Test plan

- [x] All 47 lazy-ignores tests pass (21 enabled in this PR, 26 from prior PRs)
- [x] All 14 quality gates pass (`just lint-full`)
- [x] CLI command works with text, json, sarif formats
- [x] SRP refactor: extracted `IgnoreSuppressionMatcher` to keep `LazyIgnoresRule` under method limit

## Progress

This completes **PR6** of the lazy-ignores roadmap (50% overall: PR1-3, PR6 done).

Remaining PRs:
- PR4: TypeScript/JavaScript detection
- PR5: Test skip detection  
- PR7: Dogfooding (add to `just lint-full`)
- PR8: Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)