### PR TITLE
feat(init-config): Complete template with all linters and merge behavior

### DIFF
--- a/.ai/howtos/how-to-add-linter.md
+++ b/.ai/howtos/how-to-add-linter.md
@@ -228,7 +228,43 @@ def your_linter(paths: tuple[str, ...], format: str, max_threshold: int):
     click.echo(output)
 ```
 
-### Step 7: Ensure SARIF Support
+### Step 7: Update init-config Template
+
+Add your linter's configuration section to `src/templates/thailint_config_template.yaml` so users
+can configure it when running `thailint init-config`:
+
+1. Add a section following the existing format (header comment, enabled flag, config options)
+2. Include all configurable options with their default values
+3. Add commented examples for optional settings
+4. Place the section in logical order (group similar linters together)
+
+Example section:
+
+```yaml
+# ============================================================================
+# YOUR LINTER NAME
+# ============================================================================
+# Brief description of what this linter detects
+#
+your-linter:
+  enabled: true
+
+  # Configuration option description
+  # Default: value
+  option_name: default_value
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore:
+  #   - "tests/**"
+```
+
+**Why this matters**: Users running `thailint init-config` expect to see all available linters
+with their configuration options. Missing linters from the template means users won't know they
+exist or how to configure them.
+
+### Step 8: Ensure SARIF Support
 
 Verify your linter works with all output formats:
 
@@ -245,7 +281,7 @@ thailint your-linter --format sarif . | jq
 
 **SARIF is mandatory.** See `.ai/docs/SARIF_STANDARDS.md` for requirements.
 
-### Step 8: Add CLI Integration Tests
+### Step 9: Add CLI Integration Tests
 
 Test the CLI integration:
 
@@ -294,7 +330,7 @@ class TestYourLinterCLI:
         assert "runs" in sarif
 ```
 
-### Step 9: Write Documentation
+### Step 10: Write Documentation
 
 Create user-facing documentation:
 
@@ -302,7 +338,7 @@ Create user-facing documentation:
 2. **Create docs/your-linter.md** - Detailed usage guide
 3. **Add examples** - Sample code with violations
 
-### Step 10: Final Quality Checks
+### Step 11: Final Quality Checks
 
 Before submitting your PR, verify:
 
@@ -341,6 +377,9 @@ poetry run mypy src/linters/your_linter/
 - [ ] Xenon complexity is A-grade
 - [ ] MyPy passes with no errors
 - [ ] `just lint-full` passes
+
+### Configuration
+- [ ] init-config template updated (`src/templates/thailint_config_template.yaml`)
 
 ### Documentation
 - [ ] File headers on all new files

--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ docker run --rm washad/thailint:latest --help
 ### CLI Mode
 
 ```bash
+# Generate a configuration file (first time setup)
+thailint init-config
+
+# Or use a preset (strict, standard, lenient)
+thailint init-config --preset lenient
+
 # Check file placement
 thailint file-placement .
 
@@ -244,6 +250,33 @@ docker run --rm -v $(pwd):/data \
 See **[Docker Usage](#docker-usage)** section below for more examples.
 
 ## Configuration
+
+### Generate Configuration File
+
+The easiest way to create a configuration file is with `init-config`:
+
+```bash
+# Generate .thailint.yaml with interactive prompts
+thailint init-config
+
+# Non-interactive mode (for CI/AI agents)
+thailint init-config --non-interactive
+
+# Choose a preset level
+thailint init-config --preset strict    # Only -1, 0, 1 allowed
+thailint init-config --preset standard  # Balanced defaults (default)
+thailint init-config --preset lenient   # Includes time conversions (60, 3600)
+
+# Custom output path
+thailint init-config --output my-config.yaml
+
+# Force overwrite existing config
+thailint init-config --force
+```
+
+**Merge behavior**: If `.thailint.yaml` already exists, `init-config` will add any missing linter sections without overwriting your customizations. Use `--force` to completely replace the file.
+
+### Manual Configuration
 
 Create `.thailint.yaml` in your project root:
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -66,6 +66,8 @@ thailint init-config
 - `standard`: Balanced defaults including 2, 10, 100, 1000
 - `lenient`: Includes time conversions (60s, 3600s) and common sizes (1024)
 
+**Updating existing config:** If `.thailint.yaml` already exists, `init-config` will add any missing linter sections without overwriting your customizations. Use `--force` to completely replace the file.
+
 ### Step 3: Run Your First Lint
 
 ```bash

--- a/src/cli/config_merge.py
+++ b/src/cli/config_merge.py
@@ -1,0 +1,241 @@
+"""
+Purpose: Configuration merge utilities for init-config command
+
+Scope: Functions for merging missing linter sections into existing config files
+
+Overview: Provides utilities for the init-config command to add missing linter sections
+    to existing configuration files without overwriting user customizations. Handles
+    template parsing, section extraction, missing section identification, and content
+    merging while preserving comments and formatting.
+
+Dependencies: re for pattern matching, yaml for config parsing, click for output,
+    pathlib for file operations
+
+Exports: perform_merge, LINTER_SECTIONS
+
+Interfaces: perform_merge(output_path, preset, output, generate_config_fn) -> None
+
+Implementation: Text-based parsing and merging to preserve YAML comments
+"""
+
+import re
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import click
+import yaml
+
+# Known linter section names that should be in the template
+LINTER_SECTIONS = [
+    "magic-numbers",
+    "nesting",
+    "srp",
+    "dry",
+    "file-placement",
+    "print-statements",
+    "stringly-typed",
+    "file-header",
+    "method-property",
+    "stateless-class",
+    "pipeline",
+    "lazy-ignores",
+]
+
+
+def _is_section_header_line(line: str) -> bool:
+    """Check if line is a section header (# ==== style comment)."""
+    return line.startswith("# ===")
+
+
+def _get_linter_section_name(line: str) -> str | None:
+    """Extract linter section name from line if it's a known linter section."""
+    section_match = re.match(r"^([a-z][a-z0-9-]*):$", line)
+    if section_match and section_match.group(1) in LINTER_SECTIONS:
+        return section_match.group(1)
+    return None
+
+
+def _is_buffer_line(line: str) -> bool:
+    """Check if line should be buffered (comment or empty)."""
+    stripped = line.strip()
+    return stripped.startswith("#") or stripped == ""
+
+
+def _save_current_section(
+    sections: dict[str, str], current_section: str | None, current_content: list[str]
+) -> None:
+    """Save current section to sections dict if valid."""
+    if current_section and current_content:
+        sections[current_section] = "\n".join(current_content)
+
+
+def _handle_section_header(
+    line: str, sections: dict[str, str], current_section: str | None, current_content: list[str]
+) -> tuple[str | None, list[str], list[str]]:
+    """Handle a section header line (# === style)."""
+    _save_current_section(sections, current_section, current_content)
+    return None, [], [line]
+
+
+def _start_linter_section(
+    section_name: str, line: str, header_buffer: list[str]
+) -> tuple[str | None, list[str], list[str]]:
+    """Start a new linter section with the header buffer and section line."""
+    return section_name, header_buffer + [line], []
+
+
+def _handle_content_line(
+    line: str, current_section: str | None, current_content: list[str], header_buffer: list[str]
+) -> tuple[str | None, list[str], list[str]]:
+    """Handle a regular content line."""
+    if current_section:
+        current_content.append(line)
+        return current_section, current_content, header_buffer
+    if _is_buffer_line(line):
+        header_buffer.append(line)
+        return current_section, current_content, header_buffer
+    return current_section, current_content, []
+
+
+def _process_template_line(
+    line: str,
+    sections: dict[str, str],
+    current_section: str | None,
+    current_content: list[str],
+    header_buffer: list[str],
+) -> tuple[str | None, list[str], list[str]]:
+    """Process a single template line and update state."""
+    if _is_section_header_line(line):
+        return _handle_section_header(line, sections, current_section, current_content)
+
+    section_name = _get_linter_section_name(line)
+    if section_name:
+        _save_current_section(sections, current_section, current_content)
+        return _start_linter_section(section_name, line, header_buffer)
+
+    return _handle_content_line(line, current_section, current_content, header_buffer)
+
+
+def extract_linter_sections(template: str) -> dict[str, str]:
+    """Extract each linter section from template as text blocks.
+
+    Args:
+        template: Full template content
+
+    Returns:
+        Dict mapping section name to section content (with header comments)
+    """
+    sections: dict[str, str] = {}
+    lines = template.split("\n")
+    current_section: str | None = None
+    current_content: list[str] = []
+    header_buffer: list[str] = []
+
+    for line in lines:
+        current_section, current_content, header_buffer = _process_template_line(
+            line, sections, current_section, current_content, header_buffer
+        )
+
+    # Save last section
+    if current_section and current_content:
+        sections[current_section] = "\n".join(current_content)
+
+    return sections
+
+
+def identify_missing_sections(existing_config: dict, all_sections: list[str]) -> list[str]:
+    """Identify which linter sections are missing from existing config.
+
+    Args:
+        existing_config: Parsed existing config dict
+        all_sections: List of all linter section names
+
+    Returns:
+        List of section names missing from existing config
+    """
+    return [s for s in all_sections if s not in existing_config]
+
+
+def _find_global_settings_position(content: str) -> int:
+    """Find position of GLOBAL SETTINGS section in content."""
+    marker = "# ============================================================================\n# GLOBAL SETTINGS"
+    return content.find(marker)
+
+
+def _insert_before_global_settings(content: str, sections_text: str, insert_pos: int) -> str:
+    """Insert sections before GLOBAL SETTINGS marker."""
+    return content[:insert_pos] + sections_text + "\n\n" + content[insert_pos:]
+
+
+def merge_config_sections(existing_content: str, missing_sections: dict[str, str]) -> str:
+    """Merge missing sections into existing config content.
+
+    Args:
+        existing_content: Original config file content
+        missing_sections: Dict of section name -> section content to add
+
+    Returns:
+        Merged config content with missing sections appended
+    """
+    if not missing_sections:
+        return existing_content
+
+    sections_text = "\n".join(missing_sections.values())
+    insert_pos = _find_global_settings_position(existing_content)
+
+    if insert_pos > 0:
+        return _insert_before_global_settings(existing_content, sections_text, insert_pos)
+    return existing_content.rstrip() + "\n\n" + sections_text + "\n"
+
+
+def _parse_existing_config(content: str, output: str) -> dict:
+    """Parse existing config file content as YAML."""
+    try:
+        return yaml.safe_load(content) or {}
+    except yaml.YAMLError:
+        click.echo(f"Error: Could not parse {output} as YAML", err=True)
+        click.echo("Use --force to overwrite with a fresh config", err=True)
+        sys.exit(1)
+
+
+def _build_missing_sections_dict(
+    missing_names: list[str], template_sections: dict[str, str]
+) -> dict[str, str]:
+    """Build dict of missing section name -> content."""
+    return {name: template_sections[name] for name in missing_names if name in template_sections}
+
+
+def _report_merge_results(missing_names: list[str], output: str) -> None:
+    """Report which sections were added."""
+    click.echo(f"Added {len(missing_names)} missing linter section(s) to {output}:")
+    for name in missing_names:
+        click.echo(f"  - {name}")
+
+
+def perform_merge(
+    output_path: Path, preset: str, output: str, generate_config_fn: Callable[[str], str]
+) -> None:
+    """Merge missing linter sections into existing config.
+
+    Args:
+        output_path: Path to existing config file
+        preset: Preset to use for missing sections
+        output: Output filename for display
+        generate_config_fn: Function to generate config content from preset
+    """
+    existing_content = output_path.read_text(encoding="utf-8")
+    existing_config = _parse_existing_config(existing_content, output)
+
+    template_sections = extract_linter_sections(generate_config_fn(preset))
+    missing_names = identify_missing_sections(existing_config, list(template_sections.keys()))
+
+    if not missing_names:
+        click.echo(f"{output} already contains all linter sections")
+        return
+
+    missing_sections = _build_missing_sections_dict(missing_names, template_sections)
+    merged_content = merge_config_sections(existing_content, missing_sections)
+    output_path.write_text(merged_content, encoding="utf-8")
+
+    _report_merge_results(missing_names, output)

--- a/src/templates/thailint_config_template.yaml
+++ b/src/templates/thailint_config_template.yaml
@@ -172,6 +172,133 @@ stringly-typed:
   #   - severity
 
 # ============================================================================
+# FILE HEADER LINTER
+# ============================================================================
+# Validates that files have proper documentation headers
+#
+file-header:
+  enabled: true
+
+  # Enforce atemporal language (no "currently", "now", dates)
+  # Default: true
+  enforce_atemporal: true
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: Override required fields by language
+  # -------------------------------------------------------------------------
+  # required_fields:
+  #   python: [Purpose, Scope, Overview, Dependencies, Exports, Interfaces, Implementation]
+  #   typescript: [Purpose, Scope, Overview, Dependencies, Exports, Props/Interfaces, State/Behavior]
+  #   bash: [Purpose, Scope, Overview, Dependencies, Exports, Usage, Environment]
+  #   markdown: [purpose, scope, overview, audience, status]
+  #   css: [Purpose, Scope, Overview, Dependencies, Exports, Interfaces, Environment]
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore:
+  #   - "test/**"
+  #   - "**/migrations/**"
+  #   - "**/__init__.py"
+
+# ============================================================================
+# METHOD PROPERTY LINTER
+# ============================================================================
+# Detects methods that should be @property (no args, simple return)
+#
+method-property:
+  enabled: true
+
+  # Maximum statements in method body to suggest @property
+  # Default: 3
+  max_body_statements: 3
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: Methods to ignore (exact names)
+  # -------------------------------------------------------------------------
+  # ignore_methods:
+  #   - "__str__"
+  #   - "__repr__"
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: Additional action verb prefixes to exclude
+  # -------------------------------------------------------------------------
+  # exclude_prefixes:
+  #   - "fetch_"
+  #   - "load_"
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore:
+  #   - "tests/**"
+
+# ============================================================================
+# STATELESS CLASS LINTER
+# ============================================================================
+# Detects classes with no instance state (should be modules or functions)
+#
+stateless-class:
+  enabled: true
+
+  # Minimum methods to flag a stateless class
+  # Default: 2
+  min_methods: 2
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore:
+  #   - "tests/**"
+
+# ============================================================================
+# COLLECTION PIPELINE LINTER
+# ============================================================================
+# Detects "embedded loop filtering" anti-pattern (if/continue in loops)
+# Suggests using filter(), list comprehensions, or generator expressions
+#
+pipeline:
+  enabled: true
+
+  # Minimum if/continue patterns in a loop to flag
+  # Default: 1
+  min_continues: 1
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore:
+  #   - "tests/**"
+
+# ============================================================================
+# LAZY IGNORES LINTER
+# ============================================================================
+# Detects unjustified linting suppressions (noqa, type: ignore, etc.)
+# without proper documentation in file headers
+#
+lazy-ignores:
+  enabled: true
+
+  # Pattern-specific toggles
+  check_noqa: true
+  check_type_ignore: true
+  check_pylint_disable: true
+  check_nosec: true
+  check_ts_ignore: true
+  check_eslint_disable: true
+  check_thailint_ignore: true
+  check_test_skips: true
+
+  # Check for orphaned suppressions (documented but not used)
+  check_orphaned: true
+
+  # -------------------------------------------------------------------------
+  # OPTIONAL: File patterns to ignore
+  # -------------------------------------------------------------------------
+  # ignore_patterns:
+  #   - "tests/**"
+
+# ============================================================================
 # GLOBAL SETTINGS
 # ============================================================================
 #

--- a/tests/unit/cli/__init__.py
+++ b/tests/unit/cli/__init__.py
@@ -1,0 +1,1 @@
+"""CLI tests package."""

--- a/tests/unit/cli/test_init_config_merge.py
+++ b/tests/unit/cli/test_init_config_merge.py
@@ -1,0 +1,332 @@
+"""
+Purpose: Unit tests for init-config merge functionality
+
+Scope: Tests for merging missing linter sections into existing config files
+
+Overview: Comprehensive test suite for the init-config merge feature that adds missing
+    linter configuration sections to existing .thailint.yaml files without overwriting
+    user customizations. Tests cover section detection, merge behavior, comment preservation,
+    and edge cases like empty files and malformed configs.
+
+Dependencies: pytest, click.testing for CLI runner, yaml for config parsing
+
+Exports: Test classes for merge functionality
+
+Interfaces: Standard pytest test interface
+
+Implementation: Uses pytest fixtures and Click's CliRunner for integration testing
+"""
+
+import yaml
+
+
+class TestExtractLinterSections:
+    """Tests for extracting linter sections from template."""
+
+    def test_extracts_magic_numbers_section(self):
+        """Should extract magic-numbers section with comments."""
+        from src.cli.config_merge import extract_linter_sections as _extract_linter_sections
+
+        template = """# Header comment
+magic-numbers:
+  enabled: true
+  allowed_numbers: [1, 2, 3]
+
+# Another section
+nesting:
+  enabled: true
+"""
+        sections = _extract_linter_sections(template)
+
+        assert "magic-numbers" in sections
+        assert "enabled: true" in sections["magic-numbers"]
+        assert "allowed_numbers" in sections["magic-numbers"]
+
+    def test_extracts_all_linter_sections(self):
+        """Should extract all linter sections from template."""
+        from src.cli.config_merge import extract_linter_sections as _extract_linter_sections
+
+        template = """magic-numbers:
+  enabled: true
+
+nesting:
+  enabled: true
+
+srp:
+  enabled: true
+"""
+        sections = _extract_linter_sections(template)
+
+        assert len(sections) >= 3
+        assert "magic-numbers" in sections
+        assert "nesting" in sections
+        assert "srp" in sections
+
+
+class TestIdentifyMissingSections:
+    """Tests for identifying which sections are missing from existing config."""
+
+    def test_identifies_missing_sections(self):
+        """Should identify linter sections missing from existing config."""
+        from src.cli.config_merge import identify_missing_sections as _identify_missing_sections
+
+        existing_config = {"magic-numbers": {"enabled": True}, "nesting": {"enabled": True}}
+        all_sections = ["magic-numbers", "nesting", "srp", "dry", "file-header"]
+
+        missing = _identify_missing_sections(existing_config, all_sections)
+
+        assert "srp" in missing
+        assert "dry" in missing
+        assert "file-header" in missing
+        assert "magic-numbers" not in missing
+        assert "nesting" not in missing
+
+    def test_returns_empty_when_all_present(self):
+        """Should return empty list when all sections exist."""
+        from src.cli.config_merge import identify_missing_sections as _identify_missing_sections
+
+        existing_config = {"magic-numbers": {}, "nesting": {}, "srp": {}}
+        all_sections = ["magic-numbers", "nesting", "srp"]
+
+        missing = _identify_missing_sections(existing_config, all_sections)
+
+        assert len(missing) == 0
+
+    def test_returns_all_when_config_empty(self):
+        """Should return all sections when config is empty."""
+        from src.cli.config_merge import identify_missing_sections as _identify_missing_sections
+
+        existing_config = {}
+        all_sections = ["magic-numbers", "nesting", "srp"]
+
+        missing = _identify_missing_sections(existing_config, all_sections)
+
+        assert len(missing) == 3
+
+
+class TestMergeConfigs:
+    """Tests for merging missing sections into existing config."""
+
+    def test_appends_missing_sections(self):
+        """Should append missing linter sections to existing config."""
+        from src.cli.config_merge import merge_config_sections as _merge_config_sections
+
+        existing_content = """# My config
+magic-numbers:
+  enabled: true
+  allowed_numbers: [-1, 0, 1, 2, 3]
+"""
+        missing_sections = {
+            "nesting": """# ============================================================================
+# NESTING LINTER
+# ============================================================================
+nesting:
+  enabled: true
+  max_nesting_depth: 4
+"""
+        }
+
+        merged = _merge_config_sections(existing_content, missing_sections)
+
+        assert "magic-numbers:" in merged
+        assert "allowed_numbers: [-1, 0, 1, 2, 3]" in merged  # User value preserved
+        assert "nesting:" in merged
+        assert "max_nesting_depth: 4" in merged
+
+    def test_preserves_existing_comments(self):
+        """Should preserve comments in existing config."""
+        from src.cli.config_merge import merge_config_sections as _merge_config_sections
+
+        existing_content = """# My custom header comment
+# Another comment
+magic-numbers:
+  enabled: true
+  # My inline comment
+  allowed_numbers: [1, 2, 3]
+"""
+        missing_sections = {"nesting": "nesting:\n  enabled: true\n"}
+
+        merged = _merge_config_sections(existing_content, missing_sections)
+
+        assert "# My custom header comment" in merged
+        assert "# Another comment" in merged
+        assert "# My inline comment" in merged
+
+    def test_preserves_user_customizations(self):
+        """Should not overwrite user's customized values."""
+        from src.cli.config_merge import merge_config_sections as _merge_config_sections
+
+        existing_content = """magic-numbers:
+  enabled: false  # User disabled this
+  allowed_numbers: [0, 1, 42, 100]  # Custom list
+"""
+        missing_sections = {"nesting": "nesting:\n  enabled: true\n"}
+
+        merged = _merge_config_sections(existing_content, missing_sections)
+
+        # Parse to verify values
+        config = yaml.safe_load(merged)
+        assert config["magic-numbers"]["enabled"] is False
+        assert 42 in config["magic-numbers"]["allowed_numbers"]
+
+
+class TestInitConfigMergeMode:
+    """Integration tests for init-config with merge behavior."""
+
+    def test_merges_when_file_exists(self, tmp_path):
+        """Should merge missing sections when config file exists."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        # Create existing config with only magic-numbers
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text(
+            """magic-numbers:
+  enabled: true
+  allowed_numbers: [0, 1, 42]
+"""
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        assert result.exit_code == 0
+
+        # Verify merge happened
+        content = config_path.read_text()
+        config = yaml.safe_load(content)
+
+        # User's customization preserved
+        assert 42 in config.get("magic-numbers", {}).get("allowed_numbers", [])
+        # New sections added
+        assert "nesting" in config
+        assert "srp" in config
+        assert "file-header" in config
+
+    def test_force_overwrites_completely(self, tmp_path):
+        """Should completely overwrite when --force is used."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        # Create existing config with custom value
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text(
+            """magic-numbers:
+  enabled: true
+  allowed_numbers: [42, 999]  # Will be lost with --force
+"""
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["init-config", "--non-interactive", "--force", "-o", str(config_path)]
+        )
+
+        assert result.exit_code == 0
+
+        # Verify overwrite happened
+        content = config_path.read_text()
+        config = yaml.safe_load(content)
+
+        # User's customization lost (replaced with defaults)
+        assert 42 not in config.get("magic-numbers", {}).get("allowed_numbers", [])
+        assert 999 not in config.get("magic-numbers", {}).get("allowed_numbers", [])
+
+    def test_creates_new_file_when_not_exists(self, tmp_path):
+        """Should create new file with all sections when config doesn't exist."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        config_path = tmp_path / ".thailint.yaml"
+        assert not config_path.exists()
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        assert result.exit_code == 0
+        assert config_path.exists()
+
+        config = yaml.safe_load(config_path.read_text())
+        assert "magic-numbers" in config
+        assert "nesting" in config
+        assert "srp" in config
+
+    def test_shows_merge_message_when_merging(self, tmp_path):
+        """Should show message about merged sections."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text("magic-numbers:\n  enabled: true\n")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        assert result.exit_code == 0
+        assert "Added" in result.output or "merged" in result.output.lower()
+
+
+class TestEdgeCases:
+    """Tests for edge cases in merge functionality."""
+
+    def test_handles_empty_existing_file(self, tmp_path):
+        """Should handle empty existing config file."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text("")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        assert result.exit_code == 0
+        config = yaml.safe_load(config_path.read_text())
+        assert "magic-numbers" in config
+
+    def test_handles_malformed_yaml(self, tmp_path):
+        """Should handle malformed YAML gracefully."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text("invalid: yaml: content: [")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        # Should either error gracefully or use --force behavior
+        assert result.exit_code in (0, 1)
+
+    def test_handles_config_with_only_global_settings(self, tmp_path):
+        """Should add all linter sections when only global settings exist."""
+        from click.testing import CliRunner
+
+        from src.cli_main import cli
+
+        config_path = tmp_path / ".thailint.yaml"
+        config_path.write_text(
+            """exclude:
+  - "node_modules/"
+  - ".git/"
+output_format: json
+"""
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["init-config", "--non-interactive", "-o", str(config_path)])
+
+        assert result.exit_code == 0
+        config = yaml.safe_load(config_path.read_text())
+
+        # Global settings preserved
+        assert "node_modules/" in config.get("exclude", [])
+        assert config.get("output_format") == "json"
+        # Linter sections added
+        assert "magic-numbers" in config


### PR DESCRIPTION
## Summary

- Add 5 missing linter sections to init-config template (file-header, method-property, stateless-class, pipeline, lazy-ignores)
- Implement smart merge behavior: adds missing sections to existing configs without overwriting customizations
- Update how-to-add-linter.md with Step 7 about template updates
- Update README and quick-start docs with init-config documentation

## Changes

### Template (`src/templates/thailint_config_template.yaml`)
Now includes all 12 linters instead of just 7.

### Merge Behavior (`src/cli/config_merge.py`)
When running `init-config` on an existing config:
- Missing linter sections are added
- User customizations are preserved
- YAML comments are preserved
- Use `--force` to completely replace

### Documentation
- `.ai/howtos/how-to-add-linter.md`: Added Step 7 and checklist item
- `README.md`: Added init-config section
- `docs/quick-start.md`: Added merge behavior note

## Test plan

- [x] All 15 new unit tests pass (`tests/unit/cli/test_init_config_merge.py`)
- [x] Full lint suite passes (`just lint-full`)
- [x] Pre-commit and pre-push hooks pass
- [x] Manual test: `thailint init-config --non-interactive` generates complete config

🤖 Generated with [Claude Code](https://claude.com/claude-code)