### PR TITLE
feat(publish): Add GitHub Actions workflow with auto-version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,15 @@ name: Publish
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to publish (e.g., 51.0.0)'
+      bump_type:
+        description: 'Version bump type'
         required: true
-        type: string
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
       skip_checks:
         description: 'Skip tests and linting'
         required: false
@@ -76,10 +81,37 @@ jobs:
           echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> .env
           echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> .env
 
+      - name: Calculate next version
+        id: version
+        run: |
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          echo "Current version: $CURRENT_VERSION"
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          case "${{ inputs.bump_type }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+
       - name: Run publish script
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION_INPUT: ${{ inputs.version }}
+          VERSION_INPUT: ${{ steps.version.outputs.new_version }}
         run: |
           # Make script executable
           chmod +x ./scripts/publish.sh

--- a/justfile
+++ b/justfile
@@ -978,9 +978,11 @@ _publish-docker-only:
 
 # Publish to both PyPI and Docker Hub
 # Usage:
-#   just publish                    - Interactive mode with tests and linting
-#   just publish 51.0.0             - Non-interactive with specified version
-#   just publish --skip-checks      - Skip tests and linting
-#   just publish 51.0.0 --skip-checks  - Both options
+#   just publish                         - Interactive mode with tests and linting
+#   just publish --patch                 - Auto-bump patch version (x.y.Z)
+#   just publish --minor                 - Auto-bump minor version (x.Y.0)
+#   just publish --major                 - Auto-bump major version (X.0.0)
+#   just publish 51.0.0                  - Explicit version
+#   just publish --patch --skip-checks   - Combine options
 publish *ARGS="":
     @./scripts/publish.sh {{ARGS}}


### PR DESCRIPTION
## Summary
- Refactor publish workflow into dedicated `scripts/publish.sh` script
- Simplify justfile `publish` recipe to call the script
- Add GitHub Actions workflow with `workflow_dispatch` trigger
- Add post-publish PR creation to capture version bump, badges, and lock file
- Add bump type selector (patch/minor/major) for automatic version calculation

## Usage

### GitHub Actions (Primary)
1. Go to Actions → Publish → Run workflow
2. Select bump type (patch/minor/major)
3. Optionally check "Skip tests and linting"
4. Click "Run workflow"

### Local (Fallback)
```bash
just publish --patch           # Auto-bump patch version
just publish --minor           # Auto-bump minor version  
just publish --major           # Auto-bump major version
just publish 51.0.0            # Explicit version
just publish --patch --skip-checks  # Skip quality checks
```

## Files Changed
- `scripts/publish.sh` - New script containing full publish logic
- `justfile` - Simplified publish recipe (84 lines → 9 lines)
- `.github/workflows/publish.yml` - New workflow with bump type selector

## Test Plan
- [ ] Test local publish with `--patch` flag (dry run)
- [ ] Verify GHA workflow appears in Actions tab
- [ ] Trigger test workflow with skip-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)