### PR TITLE
feat(lazy-ignores): Complete PR7 dogfooding - integrate into lint-full

### DIFF
--- a/.ai/docs/FILE_HEADER_STANDARDS.md
+++ b/.ai/docs/FILE_HEADER_STANDARDS.md
@@ -535,6 +535,39 @@ Exports: Main classes, functions, or constants this module provides
 - **Implementation**: Notable algorithms, patterns, or architectural decisions
 - **State/Behavior**: Important state management or behavioral patterns used
 - **Notes**: Any special considerations, warnings, or important operational details
+- **Suppressions**: Justified linter/type checker suppressions with explanations
+
+### Suppressions Section Format (Python Files)
+
+When a file contains legitimate ignore directives (e.g., `# nosec`, `# type: ignore`, `# pylint: disable`), document them in a Suppressions section in the file header:
+
+```python
+"""
+Purpose: Main linter rule implementation
+
+Scope: Linter rule class
+
+Overview: Implements linter with type narrowing assertions.
+
+Suppressions:
+    - B101: Type narrowing assertions after guards (can't fail at runtime)
+    - arg-type: Path type coercion handled by upstream validation
+    - too-many-instance-attributes: Components grouped in dataclass
+"""
+```
+
+**Format Rules:**
+- Each suppression on its own line with `- rule-id: justification`
+- Rule IDs should match exactly what appears in the code (e.g., `B101` for `# nosec B101`)
+- For type:ignore, use the error code (e.g., `union-attr` not `type:ignore[union-attr]`)
+- Justifications should explain WHY the ignore is legitimate, not WHAT it ignores
+
+**Example Justifications:**
+- `B101: Type narrowing assertion after _should_analyze guard (can't fail)`
+- `union-attr: _active_storage property asserts non-None`
+- `too-many-instance-attributes: Helper components grouped in dataclass`
+
+The lazy-ignores linter enforces that all ignore directives in code have matching Suppressions entries in the file header.
 
 ### Optional Fields (All Files)
 - **Related**: Links to related files, documentation, or external resources

--- a/.roadmap/in-progress/lazy-ignores/PROGRESS_TRACKER.md
+++ b/.roadmap/in-progress/lazy-ignores/PROGRESS_TRACKER.md
@@ -28,8 +28,8 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 
 ## Current Status
 
-**Current PR**: PR5 - Test Skip Detection - COMPLETE
-**Infrastructure State**: PR1-6, PR5 complete - Full lazy-ignores linter with Python, TypeScript, and test skip detection
+**Current PR**: PR7 - Dogfooding - COMPLETE
+**Infrastructure State**: PR1-7 complete - Full lazy-ignores linter integrated into lint-full pipeline
 **Feature Target**: Production-ready linter with full test coverage, integrated into thai-lint quality gates
 
 ---
@@ -93,7 +93,25 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 - [x] Added TypeScriptIgnoreDetector to module exports in __init__.py
 - [x] All quality gates pass (ruff, pylint, xenon A-grade, SRP)
 
-**Next PR**: PR7 (Dogfooding) or PR8 (Documentation)
+---
+
+### PR7 - Dogfooding - COMPLETE
+
+**Quick Summary**: Ran lazy-ignores on thai-lint itself, added to lint-full pipeline, fixed all violations.
+
+**Completed**:
+- [x] Added `lint-lazy-ignores` target to justfile
+- [x] Added lazy-ignores check to `lint-full` pipeline
+- [x] Fixed all unjustified suppressions by adding Suppressions headers
+- [x] Created `src/linters/lazy_ignores/rule_id_utils.py` for pure utility functions (SRP compliance)
+- [x] Reduced IgnoreSuppressionMatcher from 17 methods to 8 methods
+- [x] Fixed header_parser.py to skip leading comments before docstrings
+- [x] Fixed complexity issues in stateless_class/linter.py and stringly_typed/linter.py
+- [x] All 15 quality gates pass (including lazy-ignores)
+- [x] Updated FILE_HEADER_STANDARDS.md with Suppressions section format
+- [x] Updated AGENTS.md with lazy-ignores command
+
+**Next PR**: PR8 (User Documentation)
 
 ---
 
@@ -118,10 +136,10 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 
 ## Overall Progress
 
-**Total Completion**: 75% (PR1-6 complete, 6/8 PRs fully completed)
+**Total Completion**: 87.5% (PR1-7 complete, 7/8 PRs fully completed)
 
 ```
-[████████░░] 75% Complete
+[█████████░] 87.5% Complete
 ```
 
 ---
@@ -136,7 +154,7 @@ This is the **PRIMARY HANDOFF DOCUMENT** for AI agents working on the lazy-ignor
 | PR4 | TypeScript/JavaScript Detection | 🟢 Complete | 100% | Medium | P1 | TypeScriptIgnoreDetector + 17 tests |
 | PR5 | Test Skip Detection | 🟢 Complete | 100% | Low | P1 | TestSkipDetector + 24 tests + directive_utils.py |
 | PR6 | CLI Integration & Output Formats | 🟢 Complete | 100% | Medium | P0 | LazyIgnoresRule + CLI + 21 tests passing |
-| PR7 | Dogfooding - Internal Use | 🔴 Not Started | 0% | Low | P1 | Add to just lint-full, fix own violations |
+| PR7 | Dogfooding - Internal Use | 🟢 Complete | 100% | Medium | P1 | Integrated into lint-full, all 15 checks pass |
 | PR8 | Documentation & PyPI Prep | 🔴 Not Started | 0% | Low | P2 | README, examples, user docs |
 
 ### Status Legend
@@ -220,7 +238,7 @@ After completing each PR:
 The feature is complete when:
 - [ ] All 8 PRs merged to main
 - [ ] 90%+ test coverage
-- [ ] thai-lint passes its own lazy-ignores check
+- [x] thai-lint passes its own lazy-ignores check
 - [ ] Documentation published in docs/
-- [ ] Added to `just lint-full` command
+- [x] Added to `just lint-full` command
 - [ ] README.md updated with new linter

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,9 @@ just lint-security
 # Complexity analysis
 just lint-complexity
 
+# Lazy ignores (unjustified suppressions)
+just lint-lazy-ignores
+
 # ALL quality checks
 just lint-full
 ```
@@ -597,6 +600,7 @@ This systematic linting approach supports the Quality Gates requirements:
 | Complexity (Xenon) | Phase 2 | how-to-refactor-for-quality.md | `just lint-complexity` |
 | SRP violations | Phase 2 | how-to-refactor-for-quality.md | `just lint-solid` |
 | Nesting depth | Phase 2 | how-to-refactor-for-quality.md | `just lint-complexity` |
+| Unjustified suppressions | Phase 1 | FILE_HEADER_STANDARDS.md | `just lint-lazy-ignores` |
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -46,6 +46,7 @@ help:
     @echo "  just lint-stateless [FILES...] - Stateless class detection (classes → module functions)"
     @echo "  just lint-print [FILES...]     - Print statement detection (debug output in production)"
     @echo "  just lint-stringly [FILES...]  - Stringly-typed detection (strings → enums)"
+    @echo "  just lint-lazy-ignores [FILES...] - Lazy ignore detection (unjustified suppressions)"
     @echo "  just clean-cache               - Clear DRY linter cache"
     @echo "  just lint-full [FILES...]      - ALL quality checks (includes all thai-lint linters)"
     @echo "  just format                    - Auto-fix formatting and linting issues"
@@ -478,6 +479,23 @@ lint-stringly +files="src/ tests/":
         fi \
     fi
 
+# Lazy ignore detection (unjustified suppressions without header documentation)
+lint-lazy-ignores +files="src/ tests/":
+    @echo ""
+    @echo "{{BLUE}}{{BOLD}}════════════════════════════════════════════════════════════{{NC}}"
+    @echo "{{BOLD}}  LAZY IGNORES (Unjustified Suppressions){{NC}}"
+    @echo "{{BLUE}}{{BOLD}}════════════════════════════════════════════════════════════{{NC}}"
+    @echo ""
+    @SRC_TARGETS=$(just _get-src-targets {{files}}); \
+    if [ -n "$SRC_TARGETS" ]; then \
+        if poetry run thai-lint lazy-ignores $SRC_TARGETS --config .thailint.yaml 2>&1; then \
+            echo "{{GREEN}}✓ Lazy ignores checks passed{{NC}}"; \
+        else \
+            echo "{{RED}}✗ Lazy ignores checks failed{{NC}}"; \
+            exit 1; \
+        fi \
+    fi
+
 # Clear DRY linter cache
 clean-cache:
     @echo "{{BLUE}}Clearing DRY linter cache...{{NC}}"
@@ -597,6 +615,13 @@ lint-full +files="src/ tests/":
         PASSED+=("Stringly-Typed")
     else
         FAILED+=("Stringly-Typed")
+    fi
+
+    echo ""
+    if just lint-lazy-ignores {{files}}; then
+        PASSED+=("Lazy Ignores")
+    else
+        FAILED+=("Lazy Ignores")
     fi
 
     # Print summary

--- a/src/analyzers/typescript_base.py
+++ b/src/analyzers/typescript_base.py
@@ -18,6 +18,10 @@ Exports: TypeScriptBaseAnalyzer class with parsing and traversal utilities
 Interfaces: parse_typescript(code), walk_tree(node, node_type), extract_node_text(node)
 
 Implementation: Tree-sitter parser singleton, recursive AST traversal, composition pattern
+
+Suppressions:
+    - type:ignore[assignment]: Tree-sitter TS_PARSER fallback when import fails
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from typing import Any

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -16,6 +16,9 @@ Exports: cli (main Click command group with all commands registered)
 Interfaces: Single import point for CLI access via 'from src.cli import cli'
 
 Implementation: Imports submodules to trigger command registration via Click decorators
+
+Suppressions:
+    - F401: Module re-exports required for public API interface
 """
 
 # Import the CLI group from main module

--- a/src/cli/linters/__init__.py
+++ b/src/cli/linters/__init__.py
@@ -16,6 +16,9 @@ Exports: All linter command functions for reference and testing
 Interfaces: Click command decorators, integration with main CLI group
 
 Implementation: Module imports trigger command registration via Click decorator side effects
+
+Suppressions:
+    - F401: Module imports trigger Click command registration via decorator side effects
 """
 
 # Import all linter command modules to register them with the CLI

--- a/src/cli/linters/code_patterns.py
+++ b/src/cli/linters/code_patterns.py
@@ -19,6 +19,9 @@ Implementation: Click decorators for command definition, orchestrator-based lint
 
 SRP Exception: CLI command modules follow Click framework patterns requiring similar command
     structure across all linter commands. This is intentional design for consistency.
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Click commands require many parameters by framework design
 """
 # dry: ignore-block - CLI commands follow Click framework pattern with intentional repetition
 

--- a/src/cli/linters/code_smells.py
+++ b/src/cli/linters/code_smells.py
@@ -20,6 +20,10 @@ Implementation: Click decorators for command definition, orchestrator-based lint
 
 SRP Exception: CLI command modules follow Click framework patterns requiring similar command
     structure across all linter commands. This is intentional design for consistency.
+
+Suppressions:
+    too-many-arguments: Click commands require many parameters by framework design
+    too-many-positional-arguments: Click positional params match CLI arg structure
 """
 # dry: ignore-block - CLI commands follow Click framework pattern with intentional repetition
 

--- a/src/cli/linters/documentation.py
+++ b/src/cli/linters/documentation.py
@@ -19,6 +19,9 @@ Implementation: Click decorators for command definition, orchestrator-based lint
 
 SRP Exception: CLI command modules follow Click framework patterns requiring similar command
     structure across all linter commands. This is intentional design for consistency.
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Click commands require many parameters by framework design
 """
 # dry: ignore-block - CLI commands follow Click framework pattern with intentional repetition
 

--- a/src/cli/linters/structure.py
+++ b/src/cli/linters/structure.py
@@ -19,6 +19,9 @@ Implementation: Click decorators for command definition, orchestrator-based lint
 
 SRP Exception: CLI command modules follow Click framework patterns requiring similar command
     structure across all linter commands. This is intentional design for consistency.
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Click commands require many parameters by framework design
 """
 # dry: ignore-block - CLI commands follow Click framework pattern with intentional repetition
 

--- a/src/cli/linters/structure_quality.py
+++ b/src/cli/linters/structure_quality.py
@@ -19,6 +19,9 @@ Implementation: Click decorators for command definition, orchestrator-based lint
 
 SRP Exception: CLI command modules follow Click framework patterns requiring similar command
     structure across all linter commands. This is intentional design for consistency.
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Click commands require many parameters by framework design
 """
 # dry: ignore-block - CLI commands follow Click framework pattern with intentional repetition
 

--- a/src/cli_main.py
+++ b/src/cli_main.py
@@ -17,6 +17,9 @@ Exports: cli (main command group with all commands registered)
 Interfaces: Click CLI commands, integration with Orchestrator for linting execution
 
 Implementation: Module imports trigger command registration via Click decorator side effects
+
+Suppressions:
+    - F401: Module re-exports and imports trigger Click command registration via decorator side effects
 """
 
 # Import the main CLI group from the modular package

--- a/src/core/linter_utils.py
+++ b/src/core/linter_utils.py
@@ -16,6 +16,10 @@ Exports: get_metadata, get_metadata_value, load_linter_config, has_file_content
 Interfaces: All functions take BaseLintContext and return typed values (dict, str, bool, Any)
 
 Implementation: Type-safe metadata access with fallbacks, generic config loading with language support
+
+Suppressions:
+    - invalid-name: T type variable follows Python generic naming convention
+    - type:ignore[return-value]: Generic config factory with runtime type checking
 """
 
 from typing import Any, Protocol, TypeVar

--- a/src/core/violation_builder.py
+++ b/src/core/violation_builder.py
@@ -21,6 +21,9 @@ Interfaces: ViolationInfo(rule_id, file_path, line, message, column, severity),
 
 Implementation: Uses dataclass for type-safe violation info, functions provide build logic
     that constructs Violation objects with proper defaults
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Violation fields as parameters
 """
 
 from dataclasses import dataclass

--- a/src/linter_config/ignore.py
+++ b/src/linter_config/ignore.py
@@ -20,6 +20,9 @@ Interfaces: is_ignored(file_path) -> bool, has_file_ignore(file_path, rule_id) -
     has_line_ignore(code, line_num, rule_id) -> bool, should_ignore_violation(violation, content) -> bool
 
 Implementation: Modular design with extracted pure functions for pattern matching and marker detection
+
+Suppressions:
+    - global-statement: Module-level singleton pattern for parser caching (performance optimization)
 """
 
 import re

--- a/src/linters/collection_pipeline/detector.py
+++ b/src/linters/collection_pipeline/detector.py
@@ -17,6 +17,9 @@ Exports: PipelinePatternDetector class, PatternMatch dataclass
 Interfaces: PipelinePatternDetector.detect_patterns() -> list[PatternMatch]
 
 Implementation: AST visitor pattern with delegated pattern matching and suggestion generation
+
+Suppressions:
+    - invalid-name: PatternVisitor inner class follows AST NodeVisitor convention
 """
 
 import ast

--- a/src/linters/dry/block_filter.py
+++ b/src/linters/dry/block_filter.py
@@ -16,6 +16,9 @@ Exports: BaseBlockFilter, BlockFilterRegistry, KeywordArgumentFilter, ImportGrou
 Interfaces: BaseBlockFilter.should_filter(code_block, file_content) -> bool
 
 Implementation: Strategy pattern with filter registry for extensibility
+
+Suppressions:
+    - type:ignore[operator]: Tree-sitter Node comparison operations (optional dependency)
 """
 
 import ast

--- a/src/linters/dry/cache.py
+++ b/src/linters/dry/cache.py
@@ -20,6 +20,9 @@ Interfaces: DRYCache.__init__(storage_mode), add_blocks(file_path, blocks),
 
 Implementation: SQLite with three tables (files, code_blocks, constants), indexed for performance,
     storage_mode determines :memory: vs tempfile location, ACID transactions for reliability
+
+Suppressions:
+    - consider-using-with: Tempfile managed by class lifecycle, not context manager
 """
 
 from __future__ import annotations

--- a/src/linters/dry/config.py
+++ b/src/linters/dry/config.py
@@ -15,6 +15,9 @@ Exports: DRYConfig dataclass
 Interfaces: DRYConfig.__init__, DRYConfig.from_dict(config: dict) -> DRYConfig
 
 Implementation: Dataclass with field defaults, __post_init__ validation, and dict-based construction
+
+Suppressions:
+    - too-many-instance-attributes: Configuration dataclass with related settings
 """
 
 from dataclasses import dataclass, field

--- a/src/linters/dry/constant_matcher.py
+++ b/src/linters/dry/constant_matcher.py
@@ -17,6 +17,9 @@ Exports: find_constant_groups function
 Interfaces: find_constant_groups(constants) -> list[ConstantGroup]
 
 Implementation: Union-Find algorithm for grouping, word-set hashing, Levenshtein distance calculation
+
+Suppressions:
+    - arguments-out-of-order: Named arguments used for clarity in ConstantLocation
 """
 
 from collections.abc import Callable

--- a/src/linters/dry/python_analyzer.py
+++ b/src/linters/dry/python_analyzer.py
@@ -17,6 +17,10 @@ Interfaces: PythonDuplicateAnalyzer.analyze(file_path: Path, content: str, confi
 
 Implementation: Uses custom tokenizer that filters docstrings before hashing
 
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Line processing with related params
+    - type:ignore[arg-type]: ast.get_docstring returns str|None, typing limitation
+
 SRP Exception: PythonDuplicateAnalyzer has 32 methods and 358 lines (exceeds max 8 methods/200 lines)
     Justification: Complex AST analysis algorithm for duplicate code detection with sophisticated
     false positive filtering. Methods form tightly coupled algorithm pipeline: docstring extraction,
@@ -229,11 +233,11 @@ class PythonDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.violat
         Returns:
             Tuple of (new_import_state, normalized_line or None if should skip)
         """
-        normalized = self._hasher._normalize_line(line)  # pylint: disable=protected-access
+        normalized = self._hasher.normalize_line(line)
         if not normalized:
             return in_multiline_import, None
 
-        new_state, should_skip = self._hasher._should_skip_import_line(  # pylint: disable=protected-access
+        new_state, should_skip = self._hasher.should_skip_import_line(
             normalized, in_multiline_import
         )
         if should_skip:

--- a/src/linters/dry/single_statement_detector.py
+++ b/src/linters/dry/single_statement_detector.py
@@ -18,6 +18,11 @@ Interfaces: SingleStatementDetector.is_single_statement(content, start_line, end
 
 Implementation: AST walking with line-to-node index optimization for performance
 
+Suppressions:
+    - type:ignore[attr-defined]: Tree-sitter Node.text attribute access (optional dependency)
+    - type:ignore[operator]: Tree-sitter Node comparison operations (optional dependency)
+    - too-many-arguments,too-many-positional-arguments: Builder pattern with related params
+
 SRP Exception: SingleStatementDetector has 33 methods and 308 lines (exceeds max 8 methods/200 lines)
     Justification: Complex AST analysis algorithm for single-statement pattern detection with sophisticated
     false positive filtering. Methods form tightly coupled algorithm pipeline: class field detection,

--- a/src/linters/dry/token_hasher.py
+++ b/src/linters/dry/token_hasher.py
@@ -14,7 +14,9 @@ Dependencies: Python built-in hash function
 Exports: TokenHasher class
 
 Interfaces: TokenHasher.tokenize(code: str) -> list[str],
-    TokenHasher.rolling_hash(lines: list[str], window_size: int) -> list[tuple]
+    TokenHasher.rolling_hash(lines: list[str], window_size: int) -> list[tuple],
+    TokenHasher.normalize_line(line: str) -> str,
+    TokenHasher.should_skip_import_line(line: str, in_multiline_import: bool) -> tuple
 
 Implementation: Token-based normalization with rolling window algorithm, language-agnostic approach
 """
@@ -40,12 +42,12 @@ class TokenHasher:  # thailint: ignore[srp] - Methods support single responsibil
         in_multiline_import = False
 
         for line in code.split("\n"):
-            line = self._normalize_line(line)
+            line = self.normalize_line(line)
             if not line:
                 continue
 
             # Update multi-line import state and check if line should be skipped
-            in_multiline_import, should_skip = self._should_skip_import_line(
+            in_multiline_import, should_skip = self.should_skip_import_line(
                 line, in_multiline_import
             )
             if should_skip:
@@ -55,7 +57,7 @@ class TokenHasher:  # thailint: ignore[srp] - Methods support single responsibil
 
         return lines
 
-    def _normalize_line(self, line: str) -> str:
+    def normalize_line(self, line: str) -> str:
         """Normalize a line by removing comments and excess whitespace.
 
         Args:
@@ -67,7 +69,7 @@ class TokenHasher:  # thailint: ignore[srp] - Methods support single responsibil
         line = self._strip_comments(line)
         return " ".join(line.split())
 
-    def _should_skip_import_line(self, line: str, in_multiline_import: bool) -> tuple[bool, bool]:
+    def should_skip_import_line(self, line: str, in_multiline_import: bool) -> tuple[bool, bool]:
         """Determine if an import line should be skipped.
 
         Args:

--- a/src/linters/dry/typescript_analyzer.py
+++ b/src/linters/dry/typescript_analyzer.py
@@ -19,6 +19,10 @@ Interfaces: TypeScriptDuplicateAnalyzer.analyze(file_path: Path, content: str, c
 Implementation: Inherits analyze() workflow from BaseTokenAnalyzer, adds JSDoc comment extraction,
     single statement detection using tree-sitter AST patterns, and interface filtering logic
 
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
+    - invalid-name: Node type alias follows tree-sitter naming convention
+
 SRP Exception: TypeScriptDuplicateAnalyzer has 20 methods and 324 lines (exceeds max 8 methods/200 lines)
     Justification: Complex tree-sitter AST analysis algorithm for duplicate code detection with sophisticated
     false positive filtering. Mirrors Python analyzer structure. Methods form tightly coupled algorithm
@@ -228,11 +232,11 @@ class TypeScriptDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.vi
         Returns:
             Tuple of (new_import_state, normalized_line or None if should skip)
         """
-        normalized = self._hasher._normalize_line(line)  # pylint: disable=protected-access
+        normalized = self._hasher.normalize_line(line)
         if not normalized:
             return in_multiline_import, None
 
-        new_state, should_skip = self._hasher._should_skip_import_line(  # pylint: disable=protected-access
+        new_state, should_skip = self._hasher.should_skip_import_line(
             normalized, in_multiline_import
         )
         if should_skip:

--- a/src/linters/dry/typescript_constant_extractor.py
+++ b/src/linters/dry/typescript_constant_extractor.py
@@ -17,6 +17,10 @@ Exports: TypeScriptConstantExtractor class
 Interfaces: TypeScriptConstantExtractor.extract(content: str) -> list[ConstantInfo]
 
 Implementation: Tree-sitter-based parsing with const declaration filtering and ALL_CAPS regex matching
+
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
+    - broad-exception-caught: Defensive parsing for malformed TypeScript code
 """
 
 from typing import Any

--- a/src/linters/dry/typescript_statement_detector.py
+++ b/src/linters/dry/typescript_statement_detector.py
@@ -16,6 +16,9 @@ Interfaces: is_single_statement(content, start_line, end_line) -> bool,
     should_include_block(content, start_line, end_line) -> bool
 
 Implementation: Tree-sitter AST walking with pattern matching for TypeScript constructs
+
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from collections.abc import Generator

--- a/src/linters/dry/typescript_value_extractor.py
+++ b/src/linters/dry/typescript_value_extractor.py
@@ -14,6 +14,9 @@ Exports: TypeScriptValueExtractor class
 Interfaces: TypeScriptValueExtractor.get_value_string(node, content) -> str | None
 
 Implementation: Tree-sitter node traversal with type-specific string formatting
+
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from typing import Any

--- a/src/linters/file_header/linter.py
+++ b/src/linters/file_header/linter.py
@@ -20,6 +20,9 @@ Interfaces: check(context) -> list[Violation] for rule validation, standard rule
 
 Implementation: Composition pattern with helper classes for parsing, validation,
     and violation building
+
+Suppressions:
+    - type:ignore[type-var]: Protocol pattern with generic type matching
 """
 
 from pathlib import Path

--- a/src/linters/file_header/markdown_parser.py
+++ b/src/linters/file_header/markdown_parser.py
@@ -17,6 +17,9 @@ Interfaces: extract_header(code) -> str | None for frontmatter extraction,
     parse_fields(header) -> dict[str, str] for field parsing
 
 Implementation: YAML frontmatter extraction with PyYAML parsing and regex fallback for robustness
+
+Suppressions:
+    - BLE001: Broad exception catch for YAML parsing fallback (any exception triggers regex fallback)
 """
 
 import logging

--- a/src/linters/lazy_ignores/python_analyzer.py
+++ b/src/linters/lazy_ignores/python_analyzer.py
@@ -7,7 +7,8 @@ Overview: Provides PythonIgnoreDetector class that scans Python source code for 
     linting ignore patterns. Detects bare patterns (e.g., # noqa) and rule-specific
     patterns (e.g., # noqa: PLR0912). Handles case-insensitive matching and extracts
     rule IDs from comma-separated lists. Returns list of IgnoreDirective objects with
-    line/column positions for violation reporting.
+    line/column positions for violation reporting. Skips patterns inside docstrings
+    and string literals to avoid false positives.
 
 Dependencies: re for pattern matching, pathlib for file paths, types module for dataclasses
 
@@ -15,7 +16,7 @@ Exports: PythonIgnoreDetector
 
 Interfaces: find_ignores(code: str, file_path: Path | None) -> list[IgnoreDirective]
 
-Implementation: Regex-based line-by-line scanning with pattern-specific rule ID extraction
+Implementation: Regex-based line-by-line scanning with docstring-aware state tracking
 """
 
 import re
@@ -23,6 +24,65 @@ from pathlib import Path
 
 from src.linters.lazy_ignores.directive_utils import create_directive
 from src.linters.lazy_ignores.types import IgnoreDirective, IgnoreType
+
+
+def _count_unescaped_triple_quotes(line: str, quote: str) -> int:
+    """Count unescaped triple-quote occurrences in a line.
+
+    Uses regex to find non-escaped triple quotes.
+
+    Args:
+        line: Line to scan
+        quote: Triple-quote pattern to count (single or double)
+
+    Returns:
+        Number of unescaped triple-quote occurrences
+    """
+    # Pattern matches triple quotes not preceded by odd number of backslashes
+    # Escape the quote for regex
+    escaped_quote = re.escape(quote)
+    pattern = re.compile(rf"(?<!\\){escaped_quote}")
+    return len(pattern.findall(line))
+
+
+def _count_unescaped_single_quotes(text: str, quote_char: str) -> int:
+    """Count unescaped single quote characters in text.
+
+    Args:
+        text: Text to scan
+        quote_char: The quote character (' or ")
+
+    Returns:
+        Number of unescaped quote characters
+    """
+    count = 0
+    escaped = False
+    for char in text:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == quote_char:
+            count += 1
+    return count
+
+
+def _is_pattern_in_string_literal(line: str, match_start: int) -> bool:
+    """Check if a match position is inside a string literal.
+
+    Args:
+        line: The line of code
+        match_start: The start position of the pattern match
+
+    Returns:
+        True if the match is inside a string literal
+    """
+    before_match = line[:match_start]
+    single_count = _count_unescaped_single_quotes(before_match, "'")
+    double_count = _count_unescaped_single_quotes(before_match, '"')
+    return (single_count % 2 == 1) or (double_count % 2 == 1)
 
 
 class PythonIgnoreDetector:
@@ -51,6 +111,9 @@ class PythonIgnoreDetector:
     def find_ignores(self, code: str, file_path: Path | None = None) -> list[IgnoreDirective]:
         """Find all Python ignore directives in code.
 
+        Tracks docstring state across lines to avoid false positives from
+        patterns mentioned in documentation.
+
         Args:
             code: Python source code to scan
             file_path: Optional path to the source file
@@ -58,16 +121,50 @@ class PythonIgnoreDetector:
         Returns:
             List of IgnoreDirective objects for each detected ignore pattern
         """
-        directives: list[IgnoreDirective] = []
         effective_path = file_path or Path("unknown")
+        scannable_lines = self._get_scannable_lines(code)
+        directives: list[IgnoreDirective] = []
+        for line_num, line in scannable_lines:
+            directives.extend(self._scan_line(line, line_num, effective_path))
+        return directives
+
+    def _get_scannable_lines(self, code: str) -> list[tuple[int, str]]:
+        """Get lines that are not inside docstrings.
+
+        Args:
+            code: Source code to analyze
+
+        Returns:
+            List of (line_number, line_text) tuples for scannable lines
+        """
+        in_docstring = [False, False]  # [triple_double, triple_single]
+        quotes = ['"""', "'''"]
+        scannable: list[tuple[int, str]] = []
 
         for line_num, line in enumerate(code.splitlines(), start=1):
-            directives.extend(self._scan_line(line, line_num, effective_path))
+            was_in_docstring = in_docstring[0] or in_docstring[1]
+            self._update_docstring_state(line, quotes, in_docstring)
+            if not was_in_docstring:
+                scannable.append((line_num, line))
 
-        return directives
+        return scannable
+
+    def _update_docstring_state(self, line: str, quotes: list[str], state: list[bool]) -> None:
+        """Update docstring tracking state based on quotes in line.
+
+        Args:
+            line: Line to analyze
+            quotes: List of quote patterns to check
+            state: Mutable list tracking in-docstring state for each quote type
+        """
+        for i, quote in enumerate(quotes):
+            if _count_unescaped_triple_quotes(line, quote) % 2 == 1:
+                state[i] = not state[i]
 
     def _scan_line(self, line: str, line_num: int, file_path: Path) -> list[IgnoreDirective]:
         """Scan a single line for ignore patterns.
+
+        Skips patterns that appear inside string literals.
 
         Args:
             line: Line of code to scan
@@ -80,6 +177,9 @@ class PythonIgnoreDetector:
         found: list[IgnoreDirective] = []
         for ignore_type, pattern in self.PATTERNS.items():
             match = pattern.search(line)
-            if match:
-                found.append(create_directive(match, ignore_type, line_num, file_path))
+            if not match:
+                continue
+            if _is_pattern_in_string_literal(line, match.start()):
+                continue
+            found.append(create_directive(match, ignore_type, line_num, file_path))
         return found

--- a/src/linters/lazy_ignores/rule_id_utils.py
+++ b/src/linters/lazy_ignores/rule_id_utils.py
@@ -1,0 +1,180 @@
+"""
+Purpose: Pure utility functions for rule ID parsing and matching
+
+Scope: String parsing utilities for comma-separated rule lists and type:ignore formats
+
+Overview: Provides pure functions for parsing and matching rule IDs in various formats
+    used by the lazy-ignores linter. Handles comma-separated rule lists (e.g.,
+    "too-many-arguments,too-many-positional-arguments") and type:ignore bracket
+    formats (e.g., "type:ignore[arg-type,return-value]"). Functions are stateless
+    and can be easily tested in isolation.
+
+Dependencies: None (pure Python string operations)
+
+Exports: extract_type_ignore_bracket, split_comma_list, rule_in_comma_list,
+    rule_in_type_ignore_bracket, any_part_in_set, comma_list_has_used_rule,
+    type_ignore_bracket_has_used_rule
+
+Interfaces: All functions take strings/sets and return strings/bools
+
+Implementation: String parsing with early returns for invalid formats
+"""
+
+TYPE_IGNORE_PREFIX = "type:ignore["
+
+
+def extract_type_ignore_bracket(suppression_key: str) -> str | None:
+    """Extract content from type:ignore[...] format.
+
+    Args:
+        suppression_key: String that may be in type:ignore[rules] format
+
+    Returns:
+        Content between brackets, or None if not valid format
+    """
+    if not suppression_key.startswith(TYPE_IGNORE_PREFIX):
+        return None
+    if not suppression_key.endswith("]"):
+        return None
+    return suppression_key[len(TYPE_IGNORE_PREFIX) : -1]
+
+
+def split_comma_list(content: str) -> list[str]:
+    """Split comma-separated string into stripped parts.
+
+    Args:
+        content: Comma-separated string
+
+    Returns:
+        List of stripped parts, or empty list if no commas
+    """
+    if "," not in content:
+        return []
+    return [p.strip() for p in content.split(",")]
+
+
+def rule_in_comma_list(rule_id: str, suppression_key: str) -> bool:
+    """Check if rule_id is in a plain comma-separated list.
+
+    Args:
+        rule_id: Normalized rule ID to find
+        suppression_key: String that may contain comma-separated rules
+
+    Returns:
+        True if rule_id is found in the comma-separated parts
+    """
+    parts = split_comma_list(suppression_key)
+    return rule_id in parts
+
+
+def rule_in_type_ignore_bracket(rule_id: str, suppression_key: str) -> bool:
+    """Check if rule_id is in type:ignore[rule1,rule2] format.
+
+    Args:
+        rule_id: Normalized rule ID to find
+        suppression_key: String that may be in type:ignore[rules] format
+
+    Returns:
+        True if rule_id is found in the bracket content
+    """
+    bracket_content = extract_type_ignore_bracket(suppression_key)
+    if bracket_content is None:
+        return False
+    parts = split_comma_list(bracket_content)
+    return rule_id in parts
+
+
+def any_part_in_set(content: str, rule_ids: set[str]) -> bool:
+    """Check if any comma-separated part of content is in rule_ids.
+
+    Args:
+        content: Comma-separated string
+        rule_ids: Set of rule IDs to check against
+
+    Returns:
+        True if any part is in the set
+    """
+    parts = split_comma_list(content)
+    return any(p in rule_ids for p in parts)
+
+
+def comma_list_has_used_rule(suppression_key: str, used_rule_ids: set[str]) -> bool:
+    """Check if any rule in a comma-separated suppression is used.
+
+    Args:
+        suppression_key: Comma-separated suppression key
+        used_rule_ids: Set of rule IDs used in code
+
+    Returns:
+        True if any comma-separated rule is in used_rule_ids
+    """
+    parts = split_comma_list(suppression_key)
+    return any(p in used_rule_ids for p in parts)
+
+
+def type_ignore_bracket_has_used_rule(suppression_key: str, used_rule_ids: set[str]) -> bool:
+    """Check if type:ignore[rules] suppression has any used rule.
+
+    Args:
+        suppression_key: String in type:ignore[rules] format
+        used_rule_ids: Set of rule IDs used in code
+
+    Returns:
+        True if bracket content or any comma part is in used_rule_ids
+    """
+    bracket_content = extract_type_ignore_bracket(suppression_key)
+    if bracket_content is None:
+        return False
+    if bracket_content in used_rule_ids:
+        return True
+    return any_part_in_set(bracket_content, used_rule_ids)
+
+
+def is_type_ignore_format_in_suppressions(normalized: str, suppressions: dict[str, str]) -> bool:
+    """Check if type:ignore[rule] format is in suppressions.
+
+    Args:
+        normalized: Normalized rule ID
+        suppressions: Dict of suppression keys to justifications
+
+    Returns:
+        True if type:ignore[normalized] is in suppressions
+    """
+    return f"type:ignore[{normalized}]" in suppressions
+
+
+def rule_matches_suppression(rule_id: str, suppression_key: str, is_type_ignore: bool) -> bool:
+    """Check if rule_id matches a suppression key (plain or type:ignore format).
+
+    Args:
+        rule_id: Normalized rule ID to find
+        suppression_key: Suppression key to check
+        is_type_ignore: True if this is a type:ignore directive
+
+    Returns:
+        True if rule_id is found in the suppression key
+    """
+    if rule_in_comma_list(rule_id, suppression_key):
+        return True
+    if is_type_ignore:
+        return rule_in_type_ignore_bracket(rule_id, suppression_key)
+    return False
+
+
+def find_rule_in_suppressions(
+    normalized: str, suppressions: dict[str, str], is_type_ignore: bool
+) -> bool:
+    """Check if rule appears in any comma-separated suppression entry.
+
+    Args:
+        normalized: Normalized rule ID to find
+        suppressions: Dict of suppression keys to justifications
+        is_type_ignore: True if this is a type:ignore directive
+
+    Returns:
+        True if rule is found in any suppression's comma list
+    """
+    for suppression_key in suppressions:
+        if rule_matches_suppression(normalized, suppression_key, is_type_ignore):
+            return True
+    return False

--- a/src/linters/lazy_ignores/violation_builder.py
+++ b/src/linters/lazy_ignores/violation_builder.py
@@ -40,7 +40,10 @@ def build_unjustified_violation(
     Returns:
         Violation object with agent-friendly guidance message.
     """
-    message = f"Unjustified suppression found: {raw_text}"
+    message = (
+        f"Unjustified suppression found: {raw_text} "
+        f"(ASK PERMISSION before adding Suppressions header)"
+    )
 
     suggestion = _build_unjustified_suggestion(rule_id)
 

--- a/src/linters/magic_numbers/context_analyzer.py
+++ b/src/linters/magic_numbers/context_analyzer.py
@@ -21,6 +21,9 @@ Interfaces: ContextAnalyzer.is_acceptable_context(node, parent, file_path, confi
 
 Implementation: AST parent node inspection, pattern matching for acceptable contexts, configurable
     max_small_integer threshold for range detection
+
+Suppressions:
+    - B101: Assert used for internal invariant checking, not security validation
 """
 
 import ast

--- a/src/linters/magic_numbers/linter.py
+++ b/src/linters/magic_numbers/linter.py
@@ -21,10 +21,14 @@ Interfaces: MagicNumberRule.check(context) -> list[Violation], properties for ru
 
 Implementation: Composition pattern with helper classes, AST-based analysis with configurable
     allowed numbers and context detection
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: TypeScript violation creation with related params
 """
 
 import ast
 from pathlib import Path
+from typing import Any
 
 from src.core.base import BaseLintContext, MultiLanguageLintRule
 from src.core.linter_utils import load_linter_config
@@ -421,12 +425,17 @@ class MagicNumberRule(MultiLanguageLintRule):  # thailint: ignore[srp]
         return value in config.allowed_numbers or self._is_test_file(context.file_path)
 
     def _is_typescript_special_context(
-        self, node: object, analyzer: TypeScriptMagicNumberAnalyzer, context: BaseLintContext
+        self, node: Any, analyzer: TypeScriptMagicNumberAnalyzer, context: BaseLintContext
     ) -> bool:
-        """Check if in TypeScript-specific special context."""
-        # Calls require type: ignore because node is typed as object but analyzer expects Node
-        in_enum = analyzer.is_enum_context(node)  # type: ignore[arg-type]
-        in_const_def = analyzer.is_constant_definition(node, context.file_content or "")  # type: ignore[arg-type]
+        """Check if in TypeScript-specific special context.
+
+        Args:
+            node: Tree-sitter Node (typed as Any due to optional dependency)
+            analyzer: TypeScript analyzer
+            context: Lint context
+        """
+        in_enum = analyzer.is_enum_context(node)
+        in_const_def = analyzer.is_constant_definition(node, context.file_content or "")
         return in_enum or in_const_def
 
     def _is_test_file(self, file_path: object) -> bool:

--- a/src/linters/magic_numbers/typescript_analyzer.py
+++ b/src/linters/magic_numbers/typescript_analyzer.py
@@ -20,6 +20,9 @@ Interfaces: find_numeric_literals(root_node) -> list[tuple], is_enum_context(nod
 
 Implementation: Tree-sitter node traversal with visitor pattern, context-aware filtering
     for acceptable numeric literal locations
+
+Suppressions:
+    - type:ignore: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from typing import Any
@@ -43,10 +46,6 @@ class TypeScriptMagicNumberAnalyzer(TypeScriptBaseAnalyzer):  # thailint: ignore
     complexity requires extracting helper methods. Class maintains single responsibility
     of TypeScript magic number detection - all methods support this core purpose.
     """
-
-    def __init__(self) -> None:  # pylint: disable=useless-parent-delegation
-        """Initialize the TypeScript magic number analyzer."""
-        super().__init__()  # Sets self.tree_sitter_available from base class
 
     def find_numeric_literals(self, root_node: Node) -> list[tuple[Node, float | int, int]]:
         """Find all numeric literal nodes in TypeScript/JavaScript AST.

--- a/src/linters/method_property/violation_builder.py
+++ b/src/linters/method_property/violation_builder.py
@@ -16,6 +16,9 @@ Exports: ViolationBuilder class
 Interfaces: create_violation(method_name, line, column, file_path, is_get_prefix, class_name)
 
 Implementation: Builder pattern with message templates suggesting @property decorator conversion
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Violation creation with related params
 """
 
 from pathlib import Path

--- a/src/linters/nesting/typescript_analyzer.py
+++ b/src/linters/nesting/typescript_analyzer.py
@@ -16,6 +16,9 @@ Exports: TypeScriptNestingAnalyzer class with calculate_max_depth methods
 Interfaces: calculate_max_depth(func_node) -> tuple[int, int], find_all_functions(root_node)
 
 Implementation: Inherits tree-sitter parsing from base, visitor pattern with depth tracking
+
+Suppressions:
+    - type:ignore: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from typing import Any

--- a/src/linters/nesting/typescript_function_extractor.py
+++ b/src/linters/nesting/typescript_function_extractor.py
@@ -27,10 +27,6 @@ from src.analyzers.typescript_base import TypeScriptBaseAnalyzer
 class TypeScriptFunctionExtractor(TypeScriptBaseAnalyzer):
     """Extracts function information from TypeScript AST nodes."""
 
-    def __init__(self) -> None:  # pylint: disable=useless-parent-delegation
-        """Initialize the TypeScript function extractor."""
-        super().__init__()  # Sets self.tree_sitter_available from base class
-
     def collect_all_functions(self, root_node: Any) -> list[tuple[Any, str]]:
         """Collect all function nodes from TypeScript AST.
 

--- a/src/linters/print_statements/linter.py
+++ b/src/linters/print_statements/linter.py
@@ -21,6 +21,9 @@ Interfaces: check(context) -> list[Violation] for rule validation, standard rule
 
 Implementation: Composition pattern with helper classes (analyzers, violation builder),
     AST-based analysis for Python, tree-sitter for TypeScript/JavaScript
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Violation creation with related fields
 """
 
 import ast

--- a/src/linters/print_statements/typescript_analyzer.py
+++ b/src/linters/print_statements/typescript_analyzer.py
@@ -18,6 +18,9 @@ Exports: TypeScriptPrintStatementAnalyzer class
 Interfaces: find_console_calls(root_node, methods) -> list[tuple[Node, str, int]]
 
 Implementation: Tree-sitter node traversal with call_expression and member_expression pattern matching
+
+Suppressions:
+    - type:ignore: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 import logging
@@ -39,10 +42,6 @@ except ImportError:
 
 class TypeScriptPrintStatementAnalyzer(TypeScriptBaseAnalyzer):
     """Analyzes TypeScript/JavaScript code for console.* calls using Tree-sitter."""
-
-    def __init__(self) -> None:  # pylint: disable=useless-parent-delegation
-        """Initialize the TypeScript print statement analyzer."""
-        super().__init__()  # Sets self.tree_sitter_available from base class
 
     def find_console_calls(self, root_node: Node, methods: set[str]) -> list[tuple[Node, str, int]]:
         """Find all console.* calls matching the specified methods.

--- a/src/linters/srp/linter.py
+++ b/src/linters/srp/linter.py
@@ -16,6 +16,9 @@ Exports: SRPRule class
 Interfaces: SRPRule.check(context) -> list[Violation], properties for rule metadata
 
 Implementation: Composition pattern with helper classes, heuristic-based SRP analysis
+
+Suppressions:
+    - type:ignore[return-value]: Generic TypeScript analyzer return type variance
 """
 
 from src.core.base import BaseLintContext, MultiLanguageLintRule

--- a/src/linters/srp/violation_builder.py
+++ b/src/linters/srp/violation_builder.py
@@ -29,10 +29,6 @@ from src.core.violation_builder import BaseViolationBuilder, ViolationInfo
 class ViolationBuilder(BaseViolationBuilder):
     """Builds SRP violations with messages and suggestions."""
 
-    def __init__(self) -> None:  # pylint: disable=useless-parent-delegation
-        """Initialize the violation builder."""
-        super().__init__()  # Inherits from BaseViolationBuilder
-
     def build_violation(
         self,
         metrics: dict[str, Any],

--- a/src/linters/stringly_typed/config.py
+++ b/src/linters/stringly_typed/config.py
@@ -18,11 +18,10 @@ Exports: StringlyTypedConfig dataclass, default constants
 Interfaces: StringlyTypedConfig.from_dict() class method for configuration loading
 
 Implementation: Dataclass with sensible defaults, validation in __post_init__, and config
-    loading from dictionary with language-specific override support. Pylint
-    too-many-instance-attributes suppressed because configuration dataclasses inherently
-    require multiple cohesive fields (8 attributes for detection thresholds, filtering,
-    cross-file settings). Splitting would reduce cohesion without benefit. This follows
-    the established pattern in DRYConfig which has the same suppression.
+    loading from dictionary with language-specific override support
+
+Suppressions:
+    - too-many-instance-attributes: Configuration dataclass with cohesive detection settings
 """
 
 from dataclasses import dataclass, field

--- a/src/linters/stringly_typed/python/call_tracker.py
+++ b/src/linters/stringly_typed/python/call_tracker.py
@@ -17,6 +17,9 @@ Exports: FunctionCallTracker class, FunctionCallPattern dataclass
 Interfaces: FunctionCallTracker.find_patterns(tree) -> list[FunctionCallPattern]
 
 Implementation: AST NodeVisitor pattern with Call node handling for string arguments
+
+Suppressions:
+    - invalid-name: visit_Call follows AST NodeVisitor method naming convention
 """
 
 import ast

--- a/src/linters/stringly_typed/python/comparison_tracker.py
+++ b/src/linters/stringly_typed/python/comparison_tracker.py
@@ -16,6 +16,9 @@ Exports: ComparisonTracker class, ComparisonPattern dataclass
 Interfaces: ComparisonTracker.find_patterns(tree) -> list[ComparisonPattern]
 
 Implementation: AST NodeVisitor pattern with Compare node handling for string comparisons
+
+Suppressions:
+    - invalid-name: visit_Compare follows AST NodeVisitor method naming convention
 """
 
 import ast

--- a/src/linters/stringly_typed/python/condition_extractor.py
+++ b/src/linters/stringly_typed/python/condition_extractor.py
@@ -15,6 +15,9 @@ Exports: extract_from_condition, is_simple_string_equality, get_string_constant
 Interfaces: Functions for extracting string comparisons from AST nodes
 
 Implementation: Recursive traversal of BoolOp nodes with Compare extraction
+
+Suppressions:
+    - type:ignore[attr-defined]: AST node attribute access varies by node type (value.value)
 """
 
 import ast

--- a/src/linters/stringly_typed/python/conditional_detector.py
+++ b/src/linters/stringly_typed/python/conditional_detector.py
@@ -18,6 +18,9 @@ Exports: ConditionalPatternDetector class, EqualityChainPattern dataclass
 Interfaces: ConditionalPatternDetector.find_patterns(tree) -> list[EqualityChainPattern]
 
 Implementation: AST NodeVisitor pattern with If node chain traversal and Match statement handling
+
+Suppressions:
+    - invalid-name: visit_If, visit_Match follow AST NodeVisitor method naming convention
 """
 
 import ast
@@ -110,7 +113,7 @@ class ConditionalPatternDetector(ast.NodeVisitor):
         """
         pattern = analyze_match_statement(node, EqualityChainPattern)
         if pattern is not None:
-            self.patterns.append(pattern)  # type: ignore[arg-type]
+            self.patterns.append(pattern)
         self.generic_visit(node)
 
     def _analyze_if_chain(self, node: ast.If) -> None:

--- a/src/linters/stringly_typed/python/match_analyzer.py
+++ b/src/linters/stringly_typed/python/match_analyzer.py
@@ -17,16 +17,22 @@ Interfaces: MatchStatementAnalyzer.analyze(node) -> EqualityChainPattern | None
 Implementation: AST pattern matching for MatchValue nodes with string constants
 """
 
+from __future__ import annotations
+
 import ast
+from typing import TYPE_CHECKING
 
 from .constants import MIN_VALUES_FOR_PATTERN
 from .variable_extractor import extract_variable_name
 
+if TYPE_CHECKING:
+    from .conditional_detector import EqualityChainPattern
+
 
 def analyze_match_statement(
     node: ast.Match,
-    pattern_class: type,
-) -> object | None:
+    pattern_class: type[EqualityChainPattern],
+) -> EqualityChainPattern | None:
     """Analyze a match statement for string case patterns.
 
     Args:

--- a/src/linters/stringly_typed/python/validation_detector.py
+++ b/src/linters/stringly_typed/python/validation_detector.py
@@ -18,6 +18,9 @@ Exports: MembershipValidationDetector class, MembershipPattern dataclass
 Interfaces: MembershipValidationDetector.find_patterns(tree) -> list[MembershipPattern]
 
 Implementation: AST NodeVisitor pattern with Compare node handling for In/NotIn operators
+
+Suppressions:
+    - invalid-name: visit_Compare follows AST NodeVisitor method naming convention
 """
 
 import ast

--- a/src/linters/stringly_typed/typescript/call_tracker.py
+++ b/src/linters/stringly_typed/typescript/call_tracker.py
@@ -18,6 +18,9 @@ Exports: TypeScriptCallTracker class, TypeScriptFunctionCallPattern dataclass
 Interfaces: TypeScriptCallTracker.find_patterns(code) -> list[TypeScriptFunctionCallPattern]
 
 Implementation: Tree-sitter node traversal with call_expression node handling for string arguments
+
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from dataclasses import dataclass

--- a/src/linters/stringly_typed/typescript/comparison_tracker.py
+++ b/src/linters/stringly_typed/typescript/comparison_tracker.py
@@ -18,6 +18,9 @@ Interfaces: TypeScriptComparisonTracker.find_patterns(code) -> list[TypeScriptCo
 
 Implementation: Tree-sitter node traversal with binary_expression node handling for string
     comparisons
+
+Suppressions:
+    - type:ignore[assignment,misc]: Tree-sitter Node type alias (optional dependency fallback)
 """
 
 from dataclasses import dataclass

--- a/src/linters/stringly_typed/violation_generator.py
+++ b/src/linters/stringly_typed/violation_generator.py
@@ -23,6 +23,9 @@ Interfaces: ViolationGenerator.generate_violations(storage, rule_id, config) -> 
 Implementation: Queries storage, validates pattern thresholds, builds violations with
     cross-file references, delegates function call violations to builder, generates
     comparison violations from scattered string comparisons, filters by ignore directives
+
+Suppressions:
+    - too-many-arguments,too-many-positional-arguments: Violation building with related params
 """
 
 from src.core.types import Severity, Violation

--- a/src/utils/project_root.py
+++ b/src/utils/project_root.py
@@ -15,6 +15,9 @@ Exports: is_project_root(), get_project_root()
 Interfaces: Path-based functions for checking and finding project roots
 
 Implementation: pyprojroot delegation with manual fallback for test environments
+
+Suppressions:
+    - type:ignore[arg-type]: pyprojroot external library typing issue with Path conversion
 """
 
 from pathlib import Path

--- a/tests/unit/linters/lazy_ignores/test_test_skip_detection.py
+++ b/tests/unit/linters/lazy_ignores/test_test_skip_detection.py
@@ -294,15 +294,34 @@ def test_something():
         # The comment line starts with #, so our regex won't match the @
         assert len(directives) == 0
 
-    def test_skip_in_string_literal(self, detector: TestSkipDetector) -> None:
-        """Handles skip patterns in string literals."""
+    def test_skip_in_string_literal_not_detected(self, detector: TestSkipDetector) -> None:
+        """Does NOT detect skip patterns inside string literals."""
         code = """
 def test_something():
     code = "@pytest.mark.skip"
     assert True
 """
         directives = detector.find_skips(code, language="python")
-        # This is a known limitation - regex will match inside strings
-        # In a production linter we'd use AST parsing
-        # For now we accept this behavior
-        assert len(directives) >= 0  # May or may not detect
+        assert len(directives) == 0
+
+    def test_skip_in_docstring_not_detected(self, detector: TestSkipDetector) -> None:
+        """Does NOT detect skip patterns mentioned in docstrings."""
+        code = '''"""
+Purpose: Test skip detector for pytest.skip() and @pytest.mark.skip patterns
+"""
+def test_something():
+    pass
+'''
+        directives = detector.find_skips(code, language="python")
+        assert len(directives) == 0
+
+    def test_skip_description_in_docstring_not_detected(self, detector: TestSkipDetector) -> None:
+        """Does NOT detect skip pattern descriptions in docstrings."""
+        code = '''"""
+Scope: pytest.mark.skip, pytest.skip(), it.skip(), describe.skip() detection
+"""
+def test_something():
+    pass
+'''
+        directives = detector.find_skips(code, language="python")
+        assert len(directives) == 0


### PR DESCRIPTION
## Summary

- Integrate lazy-ignores linter into thai-lint's `just lint-full` quality gates (15 total checks)
- Add Suppressions headers to ~50 files with legitimate ignore directives
- Create `rule_id_utils.py` for pure parsing functions (SRP compliance)
- Reduce IgnoreSuppressionMatcher from 17 to 8 methods
- Fix B-grade complexity in `stateless_class` and `stringly_typed` linters
- Add docstring-aware scanning for Python ignore detection
- Document Suppressions format in FILE_HEADER_STANDARDS.md

## Test plan

- [x] All 15 quality gates pass (`just lint-full` exits with code 0)
- [x] Lazy-ignores check finds no violations in thai-lint source
- [x] Pre-commit hooks pass (lint, test)
- [x] Complexity now A-grade for all methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)