### PR TITLE
refactor: Convert stateless classes to module-level functions

### DIFF
--- a/src/linters/dry/python_analyzer.py
+++ b/src/linters/dry/python_analyzer.py
@@ -8,7 +8,7 @@ Overview: Analyzes Python source files to extract code blocks for duplicate dete
     Filters out docstrings at the tokenization level to prevent false positive duplication
     detection on documentation strings.
 
-Dependencies: BaseTokenAnalyzer, CodeBlock, DRYConfig, pathlib.Path, ast, TokenHasher
+Dependencies: BaseTokenAnalyzer, CodeBlock, DRYConfig, pathlib.Path, ast, token_hasher module
 
 Exports: PythonDuplicateAnalyzer class
 
@@ -37,6 +37,7 @@ SRP Exception: PythonDuplicateAnalyzer has 32 methods and 358 lines (exceeds max
 import ast
 from pathlib import Path
 
+from . import token_hasher
 from .base_token_analyzer import BaseTokenAnalyzer
 from .block_filter import BlockFilterRegistry, create_default_registry
 from .cache import CodeBlock
@@ -235,11 +236,11 @@ class PythonDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.violat
         Returns:
             Tuple of (new_import_state, normalized_line or None if should skip)
         """
-        normalized = self._hasher.normalize_line(line)
+        normalized = token_hasher.normalize_line(line)
         if not normalized:
             return in_multiline_import, None
 
-        new_state, should_skip = self._hasher.should_skip_import_line(
+        new_state, should_skip = token_hasher.should_skip_import_line(
             normalized, in_multiline_import
         )
         if should_skip:

--- a/src/linters/dry/typescript_analyzer.py
+++ b/src/linters/dry/typescript_analyzer.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from src.analyzers.typescript_base import TREE_SITTER_AVAILABLE
 
+from . import token_hasher
 from .base_token_analyzer import BaseTokenAnalyzer
 from .block_filter import BlockFilterRegistry, create_default_registry
 from .cache import CodeBlock
@@ -233,11 +234,11 @@ class TypeScriptDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.vi
         Returns:
             Tuple of (new_import_state, normalized_line or None if should skip)
         """
-        normalized = self._hasher.normalize_line(line)
+        normalized = token_hasher.normalize_line(line)
         if not normalized:
             return in_multiline_import, None
 
-        new_state, should_skip = self._hasher.should_skip_import_line(
+        new_state, should_skip = token_hasher.should_skip_import_line(
             normalized, in_multiline_import
         )
         if should_skip:

--- a/src/linters/magic_numbers/context_analyzer.py
+++ b/src/linters/magic_numbers/context_analyzer.py
@@ -3,254 +3,247 @@ Purpose: Analyzes contexts to determine if numeric literals are acceptable
 
 Scope: Context detection for magic number acceptable usage patterns
 
-Overview: Provides ContextAnalyzer class that determines whether a numeric literal is in an acceptable
+Overview: Provides module-level functions that determine whether a numeric literal is in an acceptable
     context where it should not be flagged as a magic number. Detects acceptable contexts including
     constant definitions (UPPERCASE names), small integers in range() or enumerate() calls, test files,
     and configuration contexts. Uses AST node analysis to inspect parent nodes and determine the usage
     pattern of numeric literals. Helps reduce false positives by distinguishing between legitimate
-    numeric literals and true magic numbers that should be extracted to constants. Method count (10)
-    exceeds SRP limit (8) because refactoring for A-grade complexity requires extracting helper methods.
-    Class maintains single responsibility of context analysis - all methods support this core purpose.
+    numeric literals and true magic numbers that should be extracted to constants.
 
 Dependencies: ast module for AST node types, pathlib for Path handling
 
-Exports: ContextAnalyzer class
+Exports: is_acceptable_context function and helper functions
 
-Interfaces: ContextAnalyzer.is_acceptable_context(node, parent, file_path, config) -> bool,
-    various helper methods for specific context checks
+Interfaces: is_acceptable_context(node, parent, file_path, config) -> bool
 
 Implementation: AST parent node inspection, pattern matching for acceptable contexts, configurable
     max_small_integer threshold for range detection
 
 Suppressions:
     - B101: Assert used for internal invariant checking, not security validation
-    - srp: Analyzer implements multiple context checks requiring helper methods.
-        Method count exceeds limit due to A-grade complexity refactoring.
 """
 
 import ast
 from pathlib import Path
 
 
-class ContextAnalyzer:  # thailint: ignore[srp]
-    """Analyzes contexts to determine if numeric literals are acceptable."""
+def is_acceptable_context(
+    node: ast.Constant,
+    parent: ast.AST | None,
+    file_path: Path | None,
+    config: dict,
+) -> bool:
+    """Check if a numeric literal is in an acceptable context.
 
-    def __init__(self) -> None:
-        """Initialize the context analyzer."""
-        pass  # Stateless analyzer for context checking
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
+        file_path: Path to the file being analyzed
+        config: Configuration with allowed_numbers and max_small_integer
 
-    def is_acceptable_context(
-        self,
-        node: ast.Constant,
-        parent: ast.AST | None,
-        file_path: Path | None,
-        config: dict,
-    ) -> bool:
-        """Check if a numeric literal is in an acceptable context.
+    Returns:
+        True if the context is acceptable and should not be flagged
+    """
+    # File-level and definition checks
+    if is_test_file(file_path) or is_constant_definition(node, parent):
+        return True
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
-            file_path: Path to the file being analyzed
-            config: Configuration with allowed_numbers and max_small_integer
+    # Usage pattern checks
+    return _is_acceptable_usage_pattern(node, parent, config)
 
-        Returns:
-            True if the context is acceptable and should not be flagged
-        """
-        # File-level and definition checks
-        if self.is_test_file(file_path) or self.is_constant_definition(node, parent):
-            return True
 
-        # Usage pattern checks
-        return self._is_acceptable_usage_pattern(node, parent, config)
+def _is_acceptable_usage_pattern(node: ast.Constant, parent: ast.AST | None, config: dict) -> bool:
+    """Check if numeric literal is in acceptable usage pattern.
 
-    def _is_acceptable_usage_pattern(
-        self, node: ast.Constant, parent: ast.AST | None, config: dict
-    ) -> bool:
-        """Check if numeric literal is in acceptable usage pattern.
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
+        config: Configuration with max_small_integer threshold
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
-            config: Configuration with max_small_integer threshold
+    Returns:
+        True if usage pattern is acceptable
+    """
+    if is_small_integer_in_range(node, parent, config):
+        return True
 
-        Returns:
-            True if usage pattern is acceptable
-        """
-        if self.is_small_integer_in_range(node, parent, config):
-            return True
+    if is_small_integer_in_enumerate(node, parent, config):
+        return True
 
-        if self.is_small_integer_in_enumerate(node, parent, config):
-            return True
+    return is_string_repetition(node, parent)
 
-        return self.is_string_repetition(node, parent)
 
-    def is_test_file(self, file_path: Path | None) -> bool:
-        """Check if the file is a test file.
+def is_test_file(file_path: Path | None) -> bool:
+    """Check if the file is a test file.
 
-        Args:
-            file_path: Path to the file
+    Args:
+        file_path: Path to the file
 
-        Returns:
-            True if the file is a test file (matches test_*.py pattern)
-        """
-        if not file_path:
-            return False
-        return file_path.name.startswith("test_") or "_test.py" in file_path.name
+    Returns:
+        True if the file is a test file (matches test_*.py pattern)
+    """
+    if not file_path:
+        return False
+    return file_path.name.startswith("test_") or "_test.py" in file_path.name
 
-    def is_constant_definition(self, node: ast.Constant, parent: ast.AST | None) -> bool:
-        """Check if the number is part of an UPPERCASE constant definition.
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
+def is_constant_definition(node: ast.Constant, parent: ast.AST | None) -> bool:
+    """Check if the number is part of an UPPERCASE constant definition.
 
-        Returns:
-            True if this is a constant definition
-        """
-        if not self._is_assignment_node(parent):
-            return False
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
 
-        # Type narrowing: parent is ast.Assign after the check above
-        assert isinstance(parent, ast.Assign)  # nosec B101
-        return self._has_constant_target(parent)
+    Returns:
+        True if this is a constant definition
+    """
+    if not _is_assignment_node(parent):
+        return False
 
-    def _is_assignment_node(self, parent: ast.AST | None) -> bool:
-        """Check if parent is an assignment node."""
-        return parent is not None and isinstance(parent, ast.Assign)
+    # Type narrowing: parent is ast.Assign after the check above
+    assert isinstance(parent, ast.Assign)  # nosec B101
+    return _has_constant_target(parent)
 
-    def _has_constant_target(self, parent: ast.Assign) -> bool:
-        """Check if assignment has uppercase constant target."""
-        return any(
-            isinstance(target, ast.Name) and self._is_constant_name(target.id)
-            for target in parent.targets
-        )
 
-    def _is_constant_name(self, name: str) -> bool:
-        """Check if a name follows constant naming convention.
+def _is_assignment_node(parent: ast.AST | None) -> bool:
+    """Check if parent is an assignment node."""
+    return parent is not None and isinstance(parent, ast.Assign)
 
-        Args:
-            name: Variable name to check
 
-        Returns:
-            True if the name is UPPERCASE (constant convention)
-        """
-        return name.isupper() and len(name) > 1
+def _has_constant_target(parent: ast.Assign) -> bool:
+    """Check if assignment has uppercase constant target."""
+    return any(
+        isinstance(target, ast.Name) and _is_constant_name(target.id) for target in parent.targets
+    )
 
-    def is_small_integer_in_range(
-        self, node: ast.Constant, parent: ast.AST | None, config: dict
-    ) -> bool:
-        """Check if this is a small integer used in range() call.
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
-            config: Configuration with max_small_integer threshold
+def _is_constant_name(name: str) -> bool:
+    """Check if a name follows constant naming convention.
 
-        Returns:
-            True if this is a small integer in range()
-        """
-        if not isinstance(node.value, int):
-            return False
+    Args:
+        name: Variable name to check
 
-        max_small_int = config.get("max_small_integer", 10)
-        if not 0 <= node.value <= max_small_int:
-            return False
+    Returns:
+        True if the name is UPPERCASE (constant convention)
+    """
+    return name.isupper() and len(name) > 1
 
-        return self._is_in_range_call(parent)
 
-    def is_small_integer_in_enumerate(
-        self, node: ast.Constant, parent: ast.AST | None, config: dict
-    ) -> bool:
-        """Check if this is a small integer used in enumerate() call.
+def is_small_integer_in_range(node: ast.Constant, parent: ast.AST | None, config: dict) -> bool:
+    """Check if this is a small integer used in range() call.
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
-            config: Configuration with max_small_integer threshold
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
+        config: Configuration with max_small_integer threshold
 
-        Returns:
-            True if this is a small integer in enumerate()
-        """
-        if not isinstance(node.value, int):
-            return False
+    Returns:
+        True if this is a small integer in range()
+    """
+    if not isinstance(node.value, int):
+        return False
 
-        max_small_int = config.get("max_small_integer", 10)
-        if not 0 <= node.value <= max_small_int:
-            return False
+    max_small_int = config.get("max_small_integer", 10)
+    if not 0 <= node.value <= max_small_int:
+        return False
 
-        return self._is_in_enumerate_call(parent)
+    return _is_in_range_call(parent)
 
-    def _is_in_range_call(self, parent: ast.AST | None) -> bool:
-        """Check if the parent is a range() call.
 
-        Args:
-            parent: The parent node
+def is_small_integer_in_enumerate(node: ast.Constant, parent: ast.AST | None, config: dict) -> bool:
+    """Check if this is a small integer used in enumerate() call.
 
-        Returns:
-            True if parent is range() call
-        """
-        return (
-            isinstance(parent, ast.Call)
-            and isinstance(parent.func, ast.Name)
-            and parent.func.id == "range"
-        )
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
+        config: Configuration with max_small_integer threshold
 
-    def _is_in_enumerate_call(self, parent: ast.AST | None) -> bool:
-        """Check if the parent is an enumerate() call.
+    Returns:
+        True if this is a small integer in enumerate()
+    """
+    if not isinstance(node.value, int):
+        return False
 
-        Args:
-            parent: The parent node
+    max_small_int = config.get("max_small_integer", 10)
+    if not 0 <= node.value <= max_small_int:
+        return False
 
-        Returns:
-            True if parent is enumerate() call
-        """
-        return (
-            isinstance(parent, ast.Call)
-            and isinstance(parent.func, ast.Name)
-            and parent.func.id == "enumerate"
-        )
+    return _is_in_enumerate_call(parent)
 
-    def is_string_repetition(self, node: ast.Constant, parent: ast.AST | None) -> bool:
-        """Check if this number is used in string repetition (e.g., "-" * 40).
 
-        Args:
-            node: The numeric constant node
-            parent: The parent node in the AST
+def _is_in_range_call(parent: ast.AST | None) -> bool:
+    """Check if the parent is a range() call.
 
-        Returns:
-            True if this is a string repetition pattern
-        """
-        if not isinstance(node.value, int):
-            return False
+    Args:
+        parent: The parent node
 
-        if not isinstance(parent, ast.BinOp):
-            return False
+    Returns:
+        True if parent is range() call
+    """
+    return (
+        isinstance(parent, ast.Call)
+        and isinstance(parent.func, ast.Name)
+        and parent.func.id == "range"
+    )
 
-        if not isinstance(parent.op, ast.Mult):
-            return False
 
-        # Check if either operand is a string constant
-        return self._has_string_operand(parent)
+def _is_in_enumerate_call(parent: ast.AST | None) -> bool:
+    """Check if the parent is an enumerate() call.
 
-    def _has_string_operand(self, binop: ast.BinOp) -> bool:
-        """Check if binary operation has a string operand.
+    Args:
+        parent: The parent node
 
-        Args:
-            binop: Binary operation node
+    Returns:
+        True if parent is enumerate() call
+    """
+    return (
+        isinstance(parent, ast.Call)
+        and isinstance(parent.func, ast.Name)
+        and parent.func.id == "enumerate"
+    )
 
-        Returns:
-            True if either left or right operand is a string constant
-        """
-        return self._is_string_constant(binop.left) or self._is_string_constant(binop.right)
 
-    def _is_string_constant(self, node: ast.AST) -> bool:
-        """Check if a node is a string constant.
+def is_string_repetition(node: ast.Constant, parent: ast.AST | None) -> bool:
+    """Check if this number is used in string repetition (e.g., "-" * 40).
 
-        Args:
-            node: AST node to check
+    Args:
+        node: The numeric constant node
+        parent: The parent node in the AST
 
-        Returns:
-            True if node is a Constant with string value
-        """
-        return isinstance(node, ast.Constant) and isinstance(node.value, str)
+    Returns:
+        True if this is a string repetition pattern
+    """
+    if not isinstance(node.value, int):
+        return False
+
+    if not isinstance(parent, ast.BinOp):
+        return False
+
+    if not isinstance(parent.op, ast.Mult):
+        return False
+
+    # Check if either operand is a string constant
+    return _has_string_operand(parent)
+
+
+def _has_string_operand(binop: ast.BinOp) -> bool:
+    """Check if binary operation has a string operand.
+
+    Args:
+        binop: Binary operation node
+
+    Returns:
+        True if either left or right operand is a string constant
+    """
+    return _is_string_constant(binop.left) or _is_string_constant(binop.right)
+
+
+def _is_string_constant(node: ast.AST) -> bool:
+    """Check if a node is a string constant.
+
+    Args:
+        node: AST node to check
+
+    Returns:
+        True if node is a Constant with string value
+    """
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)

--- a/src/linters/magic_numbers/linter.py
+++ b/src/linters/magic_numbers/linter.py
@@ -12,7 +12,7 @@ Overview: Implements magic numbers linter rule following BaseLintRule interface.
     because refactoring for A-grade complexity requires extracting helper methods. Class maintains
     single responsibility of magic number detection - all methods support this core purpose.
 
-Dependencies: BaseLintRule, BaseLintContext, PythonMagicNumberAnalyzer, ContextAnalyzer,
+Dependencies: BaseLintRule, BaseLintContext, PythonMagicNumberAnalyzer, is_acceptable_context,
     ViolationBuilder, MagicNumberConfig, IgnoreDirectiveParser
 
 Exports: MagicNumberRule class
@@ -39,7 +39,7 @@ from src.core.violation_utils import get_violation_line, has_python_noqa
 from src.linter_config.ignore import get_ignore_parser
 
 from .config import MagicNumberConfig
-from .context_analyzer import ContextAnalyzer
+from .context_analyzer import is_acceptable_context
 from .python_analyzer import PythonMagicNumberAnalyzer
 from .typescript_analyzer import TypeScriptMagicNumberAnalyzer
 from .typescript_ignore_checker import TypeScriptIgnoreChecker
@@ -53,7 +53,6 @@ class MagicNumberRule(MultiLanguageLintRule):  # thailint: ignore[srp]
         """Initialize the magic numbers rule."""
         self._ignore_parser = get_ignore_parser()
         self._violation_builder = ViolationBuilder(self.rule_id)
-        self._context_analyzer = ContextAnalyzer()
         self._typescript_ignore_checker = TypeScriptIgnoreChecker()
 
     @property
@@ -257,9 +256,7 @@ class MagicNumberRule(MultiLanguageLintRule):  # thailint: ignore[srp]
             "allowed_numbers": config.allowed_numbers,
         }
 
-        if self._context_analyzer.is_acceptable_context(
-            node, parent, context.file_path, config_dict
-        ):
+        if is_acceptable_context(node, parent, context.file_path, config_dict):
             return False
 
         return True

--- a/src/linters/stringly_typed/context_filter.py
+++ b/src/linters/stringly_typed/context_filter.py
@@ -11,454 +11,445 @@ Overview: Implements a blocklist-based filtering approach to reduce false positi
 
 Dependencies: re module for pattern matching
 
-Exports: FunctionCallFilter class
+Exports: should_include, are_all_values_excluded functions
 
-Interfaces: FunctionCallFilter.should_include(function_name, param_index, string_values) -> bool
+Interfaces: should_include(function_name, param_index, string_values) -> bool,
+    are_all_values_excluded(unique_values) -> bool
 
 Implementation: Blocklist-based filtering with function name patterns, parameter position rules,
     and string value pattern detection
-
-Suppressions:
-    - srp: Filter class contains extensive blocklist patterns for multiple categories.
-        Splitting by category would fragment the filtering logic.
 """
 
 import re
 
+# Function name suffixes that always indicate false positives
+_EXCLUDED_FUNCTION_SUFFIXES: tuple[str, ...] = (
+    # Exception constructors - error messages are inherently unique strings
+    "Error",
+    "Exception",
+    "Warning",
+)
 
-class FunctionCallFilter:  # thailint: ignore[srp] - data-heavy class with extensive exclusion pattern lists
-    """Filters function call violations to reduce false positives.
+# Function name patterns to always exclude (case-insensitive suffix/contains match)
+_EXCLUDED_FUNCTION_PATTERNS: tuple[str, ...] = (
+    # Dictionary/object access - these are metadata access, not domain values
+    ".get",
+    ".set",
+    ".pop",
+    ".setdefault",
+    ".update",
+    # List/collection operations
+    ".append",
+    ".extend",
+    ".insert",
+    ".add",
+    ".remove",
+    ".push",
+    ".set",
+    ".has",
+    "hasItem",
+    "push",
+    # String processing - delimiters and format strings
+    # Note: both .method and method forms to catch both method calls and standalone functions
+    ".split",
+    "split",
+    ".rsplit",
+    ".replace",
+    "replace",
+    ".strip",
+    ".rstrip",
+    ".lstrip",
+    ".startswith",
+    "startswith",
+    ".startsWith",
+    "startsWith",
+    ".endswith",
+    "endswith",
+    ".endsWith",
+    "endsWith",
+    ".includes",
+    "includes",
+    ".indexOf",
+    "indexOf",
+    ".lastIndexOf",
+    ".match",
+    ".search",
+    ".format",
+    ".join",
+    "join",
+    ".encode",
+    ".decode",
+    ".lower",
+    ".upper",
+    ".trim",
+    ".trimStart",
+    ".trimEnd",
+    ".padStart",
+    ".padEnd",
+    "strftime",
+    "strptime",
+    # Logging and output - human-readable messages
+    "logger.debug",
+    "logger.info",
+    "logger.warning",
+    "logger.error",
+    "logger.critical",
+    "logger.exception",
+    "logging.debug",
+    "logging.info",
+    "logging.warning",
+    "logging.error",
+    "print",
+    "echo",
+    "console.print",
+    "console.log",
+    "typer.echo",
+    "click.echo",
+    # Regex - pattern strings
+    "re.sub",
+    "re.match",
+    "re.search",
+    "re.compile",
+    "re.findall",
+    "re.split",
+    # Environment variables
+    "os.environ.get",
+    "os.getenv",
+    "environ.get",
+    "getenv",
+    # File operations
+    "open",
+    "Path",
+    # Framework validators - must be strings matching field names
+    "field_validator",
+    "validator",
+    "computed_field",
+    # Type system - required Python syntax
+    "TypeVar",
+    "Generic",
+    "cast",
+    # Numeric - string representations of numbers
+    "Decimal",
+    "int",
+    "float",
+    # Exception constructors - error messages
+    "ValueError",
+    "TypeError",
+    "KeyError",
+    "AttributeError",
+    "RuntimeError",
+    "Exception",
+    "raise",
+    "APIException",
+    "HTTPException",
+    "ValidationError",
+    # CLI frameworks - short flags, option names, prompts
+    "typer.Option",
+    "typer.Argument",
+    "typer.confirm",
+    "typer.prompt",
+    "click.option",
+    "click.argument",
+    "click.confirm",
+    "click.prompt",
+    ".command",
+    # HTTP/API clients - external protocol strings
+    "requests.get",
+    "requests.post",
+    "requests.put",
+    "requests.delete",
+    "requests.patch",
+    "httpx.get",
+    "httpx.post",
+    "axios.get",
+    "axios.post",
+    "axios.put",
+    "axios.delete",
+    "axios.patch",
+    "client.get",
+    "client.post",
+    "client.put",
+    "client.delete",
+    "session.client",
+    "session.resource",
+    "_request",
+    # Browser/DOM APIs - CSS selectors and data URLs
+    "document.querySelector",
+    "document.querySelectorAll",
+    "document.getElementById",
+    "document.getElementsByClassName",
+    "canvas.toDataURL",
+    "canvas.toBlob",
+    "createElement",
+    "getAttribute",
+    "setAttribute",
+    "addEventListener",
+    "removeEventListener",
+    "localStorage.getItem",
+    "localStorage.setItem",
+    "sessionStorage.getItem",
+    "sessionStorage.setItem",
+    "window.confirm",
+    "window.alert",
+    "window.prompt",
+    "confirm",
+    "alert",
+    "prompt",
+    # React hooks - internal state identifiers
+    "useRef",
+    "useState",
+    "useCallback",
+    "useMemo",
+    # AWS SDK - service names and API parameters
+    "boto3.client",
+    "boto3.resource",
+    "generate_presigned_url",
+    # AWS CDK - infrastructure as code (broad patterns)
+    "s3.",
+    "ec2.",
+    "logs.",
+    "route53.",
+    "lambda_.",
+    "_lambda.",
+    "tasks.",
+    "iam.",
+    "dynamodb.",
+    "sqs.",
+    "sns.",
+    "apigateway.",
+    "cloudfront.",
+    "cdk.",
+    "sfn.",
+    "acm.",
+    "cloudwatch.",
+    "secretsmanager.",
+    "cr.",
+    "pipes.",
+    "rds.",
+    "elasticache.",
+    "from_lookup",
+    "generate_resource_name",
+    "CfnPipe",
+    "CfnOutput",
+    # FastAPI/Starlette routing
+    "router.get",
+    "router.post",
+    "router.put",
+    "router.delete",
+    "router.patch",
+    "app.get",
+    "app.post",
+    "app.put",
+    "app.delete",
+    "@app.",
+    "@router.",
+    # DynamoDB attribute access
+    "Key",
+    "Attr",
+    "ConditionExpression",
+    # Azure CLI - external tool invocation
+    "az",
+    # Database/ORM - schema definitions
+    "op.add_column",
+    "op.drop_column",
+    "op.create_table",
+    "op.alter_column",
+    "sa.Column",
+    "sa.PrimaryKeyConstraint",
+    "sa.ForeignKeyConstraint",
+    "Column",
+    "relationship",
+    "postgresql.ENUM",
+    "ENUM",
+    # Python built-ins
+    "getattr",
+    "setattr",
+    "hasattr",
+    "delattr",
+    "isinstance",
+    "issubclass",
+    # Pydantic/dataclass fields
+    "Field",
+    "PrivateAttr",
+    # UI frameworks - display text
+    "QLabel",
+    "QPushButton",
+    "QMessageBox",
+    "QCheckBox",
+    "setWindowTitle",
+    "setText",
+    "setToolTip",
+    "setPlaceholderText",
+    "setStatusTip",
+    "Static",
+    "Label",
+    "Button",
+    # Table/grid display - formatting
+    "table.add_row",
+    "add_row",
+    "add_column",
+    "Table",
+    "Panel",
+    "Console",
+    # Testing - mocks and fixtures
+    "monkeypatch.setattr",
+    "patch",
+    "Mock",
+    "MagicMock",
+    "PropertyMock",
+    # String parsing methods - internal message processing
+    ".index",
+    ".find",
+    ".rfind",
+    ".rindex",
+    # Storybook - action handlers
+    "action",
+    "fn",
+    # React state setters - UI state names
+    "setMessage",
+    "setError",
+    "setLoading",
+    "setStatus",
+    "setText",
+    # API clients - external endpoints
+    "API.",
+    "api.",
+    # CSS/styling
+    "setStyleSheet",
+    "add_class",
+    "remove_class",
+    # JSON/serialization - output identifiers
+    "_output",
+    "json.dumps",
+    "json.loads",
+    # Health checks - framework pattern
+    "register_health_check",
+    # Config management - dynamic config keys
+    "ensure_config_section",
+    "set_config_value",
+    "get_config_value",
+)
 
-    Uses a blocklist approach to exclude known false positive patterns:
-    - Dictionary/object access methods (.get, .set, .pop)
-    - String processing methods (split, replace, strip, strftime)
-    - Logging and output functions (logger.*, print, echo)
-    - Framework-specific patterns (Pydantic validators, TypeVar)
-    - External API functions (boto3, HTTP clients)
-    - File and path operations
+# Function names where second parameter (index 1) should be excluded
+# These are typically default values, not keys
+_EXCLUDE_PARAM_INDEX_1: tuple[str, ...] = (
+    ".get",
+    "os.environ.get",
+    "environ.get",
+    "getattr",
+    "os.getenv",
+    "getenv",
+)
+
+# String value patterns that indicate false positives
+_EXCLUDED_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # strftime format strings
+    re.compile(r"^%[A-Za-z%-]+$"),
+    # Single character delimiters
+    re.compile(r"^[\n\t\r,;:|/\\.\-_]$"),
+    # Empty string or whitespace only
+    re.compile(r"^\s*$"),
+    # HTTP methods (external protocol)
+    re.compile(r"^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$"),
+    # Numeric strings (should use Decimal or int)
+    re.compile(r"^-?\d+\.?\d*$"),
+    # Short CLI flags
+    re.compile(r"^-[a-zA-Z]$"),
+    # CSS/Rich markup
+    re.compile(r"^\[/?[a-z]+\]"),
+    # File modes (only multi-char modes to avoid false positives on single letters)
+    re.compile(r"^[rwa][bt]\+?$|^[rwa]\+$"),
+)
+
+
+def should_include(
+    function_name: str,
+    param_index: int,
+    unique_values: set[str],
+) -> bool:
+    """Determine if a function call pattern should be included in violations.
+
+    Args:
+        function_name: Name of the function being called
+        param_index: Index of the parameter (0-based)
+        unique_values: Set of unique string values passed to this parameter
+
+    Returns:
+        True if this pattern should generate a violation, False to filter it out
     """
+    # Check function name patterns
+    if _is_excluded_function(function_name):
+        return False
 
-    # Function name suffixes that always indicate false positives
-    _EXCLUDED_FUNCTION_SUFFIXES: tuple[str, ...] = (
-        # Exception constructors - error messages are inherently unique strings
-        "Error",
-        "Exception",
-        "Warning",
-    )
+    # Check parameter position for specific functions
+    if _is_excluded_param_position(function_name, param_index):
+        return False
 
-    # Function name patterns to always exclude (case-insensitive suffix/contains match)
-    _EXCLUDED_FUNCTION_PATTERNS: tuple[str, ...] = (
-        # Dictionary/object access - these are metadata access, not domain values
-        ".get",
-        ".set",
-        ".pop",
-        ".setdefault",
-        ".update",
-        # List/collection operations
-        ".append",
-        ".extend",
-        ".insert",
-        ".add",
-        ".remove",
-        ".push",
-        ".set",
-        ".has",
-        "hasItem",
-        "push",
-        # String processing - delimiters and format strings
-        # Note: both .method and method forms to catch both method calls and standalone functions
-        ".split",
-        "split",
-        ".rsplit",
-        ".replace",
-        "replace",
-        ".strip",
-        ".rstrip",
-        ".lstrip",
-        ".startswith",
-        "startswith",
-        ".startsWith",
-        "startsWith",
-        ".endswith",
-        "endswith",
-        ".endsWith",
-        "endsWith",
-        ".includes",
-        "includes",
-        ".indexOf",
-        "indexOf",
-        ".lastIndexOf",
-        ".match",
-        ".search",
-        ".format",
-        ".join",
-        "join",
-        ".encode",
-        ".decode",
-        ".lower",
-        ".upper",
-        ".trim",
-        ".trimStart",
-        ".trimEnd",
-        ".padStart",
-        ".padEnd",
-        "strftime",
-        "strptime",
-        # Logging and output - human-readable messages
-        "logger.debug",
-        "logger.info",
-        "logger.warning",
-        "logger.error",
-        "logger.critical",
-        "logger.exception",
-        "logging.debug",
-        "logging.info",
-        "logging.warning",
-        "logging.error",
-        "print",
-        "echo",
-        "console.print",
-        "console.log",
-        "typer.echo",
-        "click.echo",
-        # Regex - pattern strings
-        "re.sub",
-        "re.match",
-        "re.search",
-        "re.compile",
-        "re.findall",
-        "re.split",
-        # Environment variables
-        "os.environ.get",
-        "os.getenv",
-        "environ.get",
-        "getenv",
-        # File operations
-        "open",
-        "Path",
-        # Framework validators - must be strings matching field names
-        "field_validator",
-        "validator",
-        "computed_field",
-        # Type system - required Python syntax
-        "TypeVar",
-        "Generic",
-        "cast",
-        # Numeric - string representations of numbers
-        "Decimal",
-        "int",
-        "float",
-        # Exception constructors - error messages
-        "ValueError",
-        "TypeError",
-        "KeyError",
-        "AttributeError",
-        "RuntimeError",
-        "Exception",
-        "raise",
-        "APIException",
-        "HTTPException",
-        "ValidationError",
-        # CLI frameworks - short flags, option names, prompts
-        "typer.Option",
-        "typer.Argument",
-        "typer.confirm",
-        "typer.prompt",
-        "click.option",
-        "click.argument",
-        "click.confirm",
-        "click.prompt",
-        ".command",
-        # HTTP/API clients - external protocol strings
-        "requests.get",
-        "requests.post",
-        "requests.put",
-        "requests.delete",
-        "requests.patch",
-        "httpx.get",
-        "httpx.post",
-        "axios.get",
-        "axios.post",
-        "axios.put",
-        "axios.delete",
-        "axios.patch",
-        "client.get",
-        "client.post",
-        "client.put",
-        "client.delete",
-        "session.client",
-        "session.resource",
-        "_request",
-        # Browser/DOM APIs - CSS selectors and data URLs
-        "document.querySelector",
-        "document.querySelectorAll",
-        "document.getElementById",
-        "document.getElementsByClassName",
-        "canvas.toDataURL",
-        "canvas.toBlob",
-        "createElement",
-        "getAttribute",
-        "setAttribute",
-        "addEventListener",
-        "removeEventListener",
-        "localStorage.getItem",
-        "localStorage.setItem",
-        "sessionStorage.getItem",
-        "sessionStorage.setItem",
-        "window.confirm",
-        "window.alert",
-        "window.prompt",
-        "confirm",
-        "alert",
-        "prompt",
-        # React hooks - internal state identifiers
-        "useRef",
-        "useState",
-        "useCallback",
-        "useMemo",
-        # AWS SDK - service names and API parameters
-        "boto3.client",
-        "boto3.resource",
-        "generate_presigned_url",
-        # AWS CDK - infrastructure as code (broad patterns)
-        "s3.",
-        "ec2.",
-        "logs.",
-        "route53.",
-        "lambda_.",
-        "_lambda.",
-        "tasks.",
-        "iam.",
-        "dynamodb.",
-        "sqs.",
-        "sns.",
-        "apigateway.",
-        "cloudfront.",
-        "cdk.",
-        "sfn.",
-        "acm.",
-        "cloudwatch.",
-        "secretsmanager.",
-        "cr.",
-        "pipes.",
-        "rds.",
-        "elasticache.",
-        "from_lookup",
-        "generate_resource_name",
-        "CfnPipe",
-        "CfnOutput",
-        # FastAPI/Starlette routing
-        "router.get",
-        "router.post",
-        "router.put",
-        "router.delete",
-        "router.patch",
-        "app.get",
-        "app.post",
-        "app.put",
-        "app.delete",
-        "@app.",
-        "@router.",
-        # DynamoDB attribute access
-        "Key",
-        "Attr",
-        "ConditionExpression",
-        # Azure CLI - external tool invocation
-        "az",
-        # Database/ORM - schema definitions
-        "op.add_column",
-        "op.drop_column",
-        "op.create_table",
-        "op.alter_column",
-        "sa.Column",
-        "sa.PrimaryKeyConstraint",
-        "sa.ForeignKeyConstraint",
-        "Column",
-        "relationship",
-        "postgresql.ENUM",
-        "ENUM",
-        # Python built-ins
-        "getattr",
-        "setattr",
-        "hasattr",
-        "delattr",
-        "isinstance",
-        "issubclass",
-        # Pydantic/dataclass fields
-        "Field",
-        "PrivateAttr",
-        # UI frameworks - display text
-        "QLabel",
-        "QPushButton",
-        "QMessageBox",
-        "QCheckBox",
-        "setWindowTitle",
-        "setText",
-        "setToolTip",
-        "setPlaceholderText",
-        "setStatusTip",
-        "Static",
-        "Label",
-        "Button",
-        # Table/grid display - formatting
-        "table.add_row",
-        "add_row",
-        "add_column",
-        "Table",
-        "Panel",
-        "Console",
-        # Testing - mocks and fixtures
-        "monkeypatch.setattr",
-        "patch",
-        "Mock",
-        "MagicMock",
-        "PropertyMock",
-        # String parsing methods - internal message processing
-        ".index",
-        ".find",
-        ".rfind",
-        ".rindex",
-        # Storybook - action handlers
-        "action",
-        "fn",
-        # React state setters - UI state names
-        "setMessage",
-        "setError",
-        "setLoading",
-        "setStatus",
-        "setText",
-        # API clients - external endpoints
-        "API.",
-        "api.",
-        # CSS/styling
-        "setStyleSheet",
-        "add_class",
-        "remove_class",
-        # JSON/serialization - output identifiers
-        "_output",
-        "json.dumps",
-        "json.loads",
-        # Health checks - framework pattern
-        "register_health_check",
-        # Config management - dynamic config keys
-        "ensure_config_section",
-        "set_config_value",
-        "get_config_value",
-    )
+    # Check if all values match excluded patterns
+    if _all_values_excluded(unique_values):
+        return False
 
-    # Function names where second parameter (index 1) should be excluded
-    # These are typically default values, not keys
-    _EXCLUDE_PARAM_INDEX_1: tuple[str, ...] = (
-        ".get",
-        "os.environ.get",
-        "environ.get",
-        "getattr",
-        "os.getenv",
-        "getenv",
-    )
+    return True
 
-    # String value patterns that indicate false positives
-    _EXCLUDED_VALUE_PATTERNS: tuple[re.Pattern[str], ...] = (
-        # strftime format strings
-        re.compile(r"^%[A-Za-z%-]+$"),
-        # Single character delimiters
-        re.compile(r"^[\n\t\r,;:|/\\.\-_]$"),
-        # Empty string or whitespace only
-        re.compile(r"^\s*$"),
-        # HTTP methods (external protocol)
-        re.compile(r"^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)$"),
-        # Numeric strings (should use Decimal or int)
-        re.compile(r"^-?\d+\.?\d*$"),
-        # Short CLI flags
-        re.compile(r"^-[a-zA-Z]$"),
-        # CSS/Rich markup
-        re.compile(r"^\[/?[a-z]+\]"),
-        # File modes (only multi-char modes to avoid false positives on single letters)
-        re.compile(r"^[rwa][bt]\+?$|^[rwa]\+$"),
-    )
 
-    def should_include(
-        self,
-        function_name: str,
-        param_index: int,
-        unique_values: set[str],
-    ) -> bool:
-        """Determine if a function call pattern should be included in violations.
+def are_all_values_excluded(unique_values: set[str]) -> bool:
+    """Check if all values match excluded patterns (numeric strings, delimiters, etc.).
 
-        Args:
-            function_name: Name of the function being called
-            param_index: Index of the parameter (0-based)
-            unique_values: Set of unique string values passed to this parameter
+    Public interface for value-based filtering used by violation generator.
 
-        Returns:
-            True if this pattern should generate a violation, False to filter it out
-        """
-        # Check function name patterns
-        if self._is_excluded_function(function_name):
-            return False
+    Args:
+        unique_values: Set of unique string values to check
 
-        # Check parameter position for specific functions
-        if self._is_excluded_param_position(function_name, param_index):
-            return False
+    Returns:
+        True if all values match excluded patterns, False otherwise
+    """
+    return _all_values_excluded(unique_values)
 
-        # Check if all values match excluded patterns
-        if self._all_values_excluded(unique_values):
-            return False
 
+def _is_excluded_function(function_name: str) -> bool:
+    """Check if function name matches any excluded pattern."""
+    # Check suffix patterns (e.g., *Error, *Exception)
+    if _matches_suffix(function_name):
         return True
+    return _matches_pattern(function_name.lower())
 
-    def are_all_values_excluded(self, unique_values: set[str]) -> bool:
-        """Check if all values match excluded patterns (numeric strings, delimiters, etc.).
 
-        Public interface for value-based filtering used by violation generator.
+def _matches_suffix(function_name: str) -> bool:
+    """Check if function name ends with an excluded suffix."""
+    return any(function_name.endswith(s) for s in _EXCLUDED_FUNCTION_SUFFIXES)
 
-        Args:
-            unique_values: Set of unique string values to check
 
-        Returns:
-            True if all values match excluded patterns, False otherwise
-        """
-        return self._all_values_excluded(unique_values)
-
-    def _is_excluded_function(self, function_name: str) -> bool:
-        """Check if function name matches any excluded pattern."""
-        # Check suffix patterns (e.g., *Error, *Exception)
-        if self._matches_suffix(function_name):
+def _matches_pattern(func_lower: str) -> bool:
+    """Check if function name matches any excluded pattern."""
+    for pattern in _EXCLUDED_FUNCTION_PATTERNS:
+        pattern_lower = pattern.lower()
+        if pattern_lower in func_lower or func_lower.endswith(pattern_lower):
             return True
-        return self._matches_pattern(function_name.lower())
+    return False
 
-    def _matches_suffix(self, function_name: str) -> bool:
-        """Check if function name ends with an excluded suffix."""
-        return any(function_name.endswith(s) for s in self._EXCLUDED_FUNCTION_SUFFIXES)
 
-    def _matches_pattern(self, func_lower: str) -> bool:
-        """Check if function name matches any excluded pattern."""
-        for pattern in self._EXCLUDED_FUNCTION_PATTERNS:
-            pattern_lower = pattern.lower()
-            if pattern_lower in func_lower or func_lower.endswith(pattern_lower):
-                return True
+def _is_excluded_param_position(function_name: str, param_index: int) -> bool:
+    """Check if this parameter position should be excluded for this function."""
+    if param_index != 1:
         return False
 
-    def _is_excluded_param_position(self, function_name: str, param_index: int) -> bool:
-        """Check if this parameter position should be excluded for this function."""
-        if param_index != 1:
-            return False
-
-        func_lower = function_name.lower()
-        for pattern in self._EXCLUDE_PARAM_INDEX_1:
-            if pattern.lower() in func_lower or func_lower.endswith(pattern.lower()):
-                return True
-        return False
-
-    def _all_values_excluded(self, unique_values: set[str]) -> bool:
-        """Check if all values in the set match excluded patterns."""
-        if not unique_values:
+    func_lower = function_name.lower()
+    for pattern in _EXCLUDE_PARAM_INDEX_1:
+        if pattern.lower() in func_lower or func_lower.endswith(pattern.lower()):
             return True
-        return all(self._is_excluded_value(value) for value in unique_values)
+    return False
 
-    def _is_excluded_value(self, value: str) -> bool:
-        """Check if a single value matches any excluded pattern."""
-        for pattern in self._EXCLUDED_VALUE_PATTERNS:
-            if pattern.match(value):
-                return True
-        return False
+
+def _all_values_excluded(unique_values: set[str]) -> bool:
+    """Check if all values in the set match excluded patterns."""
+    if not unique_values:
+        return True
+    return all(_is_excluded_value(value) for value in unique_values)
+
+
+def _is_excluded_value(value: str) -> bool:
+    """Check if a single value matches any excluded pattern."""
+    for pattern in _EXCLUDED_VALUE_PATTERNS:
+        if pattern.match(value):
+            return True
+    return False

--- a/src/linters/stringly_typed/violation_generator.py
+++ b/src/linters/stringly_typed/violation_generator.py
@@ -33,8 +33,8 @@ Suppressions:
 
 from src.core.types import Severity, Violation
 
+from . import context_filter
 from .config import StringlyTypedConfig
-from .context_filter import FunctionCallFilter
 from .function_call_violation_builder import build_function_call_violations
 from .ignore_checker import IgnoreChecker
 from .ignore_utils import is_ignored
@@ -58,7 +58,6 @@ class ViolationGenerator:  # thailint: ignore[srp]
 
     def __init__(self) -> None:
         """Initialize with helper filters."""
-        self._call_filter = FunctionCallFilter()
         self._ignore_checker = IgnoreChecker()
 
     def generate_violations(
@@ -157,7 +156,7 @@ class ViolationGenerator:  # thailint: ignore[srp]
             (name, idx, vals)
             for name, idx, vals in limited_funcs
             if not _is_allowed_value_set(vals, config)
-            and self._call_filter.should_include(name, idx, vals)
+            and context_filter.should_include(name, idx, vals)
         ]
 
     def _build_call_violations(
@@ -184,7 +183,7 @@ class ViolationGenerator:  # thailint: ignore[srp]
         if self._is_pattern_allowed(first, config):
             return True
         # Skip if all values match excluded patterns (numeric strings, etc.)
-        if self._call_filter.are_all_values_excluded(set(first.string_values)):
+        if context_filter.are_all_values_excluded(set(first.string_values)):
             return True
         return False
 
@@ -310,7 +309,7 @@ class ViolationGenerator:  # thailint: ignore[srp]
             return True
         if _is_allowed_value_set(unique_values, config):
             return True
-        if self._call_filter.are_all_values_excluded(unique_values):
+        if context_filter.are_all_values_excluded(unique_values):
             return True
         return False
 

--- a/tests/unit/linters/stringly_typed/test_context_filter.py
+++ b/tests/unit/linters/stringly_typed/test_context_filter.py
@@ -1,7 +1,7 @@
 """
 Purpose: Tests for stringly-typed context-aware false positive filtering
 
-Scope: Test FunctionCallFilter class for blocklist-based filtering
+Scope: Test context_filter module functions for blocklist-based filtering
 
 Overview: Test suite validating the context-aware filtering of function call patterns
     to reduce false positives. Tests cover function name exclusion, parameter position
@@ -11,180 +11,158 @@ Dependencies: pytest, src.linters.stringly_typed.context_filter
 
 Exports: Test functions for context filter validation
 
-Interfaces: Direct testing of FunctionCallFilter class
+Interfaces: Direct testing of context_filter module functions
 
 Implementation: TDD approach with isolated test cases
 """
 
-import pytest
-
-from src.linters.stringly_typed.context_filter import FunctionCallFilter
+from src.linters.stringly_typed import context_filter
 
 
 class TestFunctionNameExclusion:
     """Tests for function name pattern exclusion."""
 
-    @pytest.fixture
-    def filter(self):
-        """Create filter instance."""
-        return FunctionCallFilter()
-
-    def test_excludes_dict_get(self, filter):
+    def test_excludes_dict_get(self):
         """Test that dict.get() is excluded."""
-        assert not filter.should_include("obj.get", 0, {"key1", "key2"})
+        assert not context_filter.should_include("obj.get", 0, {"key1", "key2"})
 
-    def test_excludes_dict_set(self, filter):
+    def test_excludes_dict_set(self):
         """Test that dict.set() is excluded."""
-        assert not filter.should_include("obj.set", 0, {"key1", "key2"})
+        assert not context_filter.should_include("obj.set", 0, {"key1", "key2"})
 
-    def test_excludes_dict_pop(self, filter):
+    def test_excludes_dict_pop(self):
         """Test that dict.pop() is excluded."""
-        assert not filter.should_include("config.pop", 0, {"key1", "key2"})
+        assert not context_filter.should_include("config.pop", 0, {"key1", "key2"})
 
-    def test_excludes_string_split(self, filter):
+    def test_excludes_string_split(self):
         """Test that str.split() is excluded."""
-        assert not filter.should_include("text.split", 0, {",", ";"})
+        assert not context_filter.should_include("text.split", 0, {",", ";"})
 
-    def test_excludes_string_replace(self, filter):
+    def test_excludes_string_replace(self):
         """Test that str.replace() is excluded."""
-        assert not filter.should_include("value.replace", 0, {"old", "new"})
+        assert not context_filter.should_include("value.replace", 0, {"old", "new"})
 
-    def test_excludes_logger_info(self, filter):
+    def test_excludes_logger_info(self):
         """Test that logger.info() is excluded."""
-        assert not filter.should_include("logger.info", 0, {"message1", "message2"})
+        assert not context_filter.should_include("logger.info", 0, {"message1", "message2"})
 
-    def test_excludes_logger_warning(self, filter):
+    def test_excludes_logger_warning(self):
         """Test that logger.warning() is excluded."""
-        assert not filter.should_include("logger.warning", 0, {"warn1", "warn2"})
+        assert not context_filter.should_include("logger.warning", 0, {"warn1", "warn2"})
 
-    def test_excludes_print(self, filter):
+    def test_excludes_print(self):
         """Test that print() is excluded."""
-        assert not filter.should_include("print", 0, {"output1", "output2"})
+        assert not context_filter.should_include("print", 0, {"output1", "output2"})
 
-    def test_excludes_typer_option(self, filter):
+    def test_excludes_typer_option(self):
         """Test that typer.Option() is excluded."""
-        assert not filter.should_include("typer.Option", 0, {"--flag", "--verbose"})
+        assert not context_filter.should_include("typer.Option", 0, {"--flag", "--verbose"})
 
-    def test_excludes_value_error(self, filter):
+    def test_excludes_value_error(self):
         """Test that ValueError() is excluded."""
-        assert not filter.should_include("ValueError", 0, {"error1", "error2"})
+        assert not context_filter.should_include("ValueError", 0, {"error1", "error2"})
 
-    def test_excludes_boto3_client(self, filter):
+    def test_excludes_boto3_client(self):
         """Test that boto3.client() is excluded."""
-        assert not filter.should_include("boto3.client", 0, {"s3", "dynamodb"})
+        assert not context_filter.should_include("boto3.client", 0, {"s3", "dynamodb"})
 
-    def test_excludes_getattr(self, filter):
+    def test_excludes_getattr(self):
         """Test that getattr() is excluded."""
-        assert not filter.should_include("getattr", 0, {"attr1", "attr2"})
+        assert not context_filter.should_include("getattr", 0, {"attr1", "attr2"})
 
-    def test_excludes_router_get(self, filter):
+    def test_excludes_router_get(self):
         """Test that router.get() is excluded."""
-        assert not filter.should_include("router.get", 0, {"/path1", "/path2"})
+        assert not context_filter.should_include("router.get", 0, {"/path1", "/path2"})
 
-    def test_excludes_s3_bucket(self, filter):
+    def test_excludes_s3_bucket(self):
         """Test that s3.Bucket() is excluded (AWS CDK)."""
-        assert not filter.should_include("s3.Bucket", 0, {"bucket1", "bucket2"})
+        assert not context_filter.should_include("s3.Bucket", 0, {"bucket1", "bucket2"})
 
-    def test_includes_custom_function(self, filter):
+    def test_includes_custom_function(self):
         """Test that custom functions are included."""
-        assert filter.should_include("process_status", 0, {"active", "inactive"})
+        assert context_filter.should_include("process_status", 0, {"active", "inactive"})
 
-    def test_includes_domain_function(self, filter):
+    def test_includes_domain_function(self):
         """Test that domain-specific functions are included."""
-        assert filter.should_include("set_environment", 0, {"production", "staging"})
+        assert context_filter.should_include("set_environment", 0, {"production", "staging"})
 
 
 class TestParameterPositionExclusion:
     """Tests for parameter position-based exclusion."""
 
-    @pytest.fixture
-    def filter(self):
-        """Create filter instance."""
-        return FunctionCallFilter()
-
-    def test_excludes_get_default_value(self, filter):
+    def test_excludes_get_default_value(self):
         """Test that dict.get() default value (param 1) is excluded."""
-        assert not filter.should_include("config.get", 1, {"default1", "default2"})
+        assert not context_filter.should_include("config.get", 1, {"default1", "default2"})
 
-    def test_includes_get_key(self, filter):
+    def test_includes_get_key(self):
         """Test that dict.get() key (param 0) is excluded for other reasons."""
         # Note: .get is excluded entirely, so this returns False
-        assert not filter.should_include("config.get", 0, {"key1", "key2"})
+        assert not context_filter.should_include("config.get", 0, {"key1", "key2"})
 
-    def test_excludes_getattr_default(self, filter):
+    def test_excludes_getattr_default(self):
         """Test that getattr() default value (param 1) is excluded."""
-        assert not filter.should_include("getattr", 1, {"default1", "default2"})
+        assert not context_filter.should_include("getattr", 1, {"default1", "default2"})
 
-    def test_excludes_environ_get_default(self, filter):
+    def test_excludes_environ_get_default(self):
         """Test that os.environ.get() default (param 1) is excluded."""
-        assert not filter.should_include("os.environ.get", 1, {"default1", "default2"})
+        assert not context_filter.should_include("os.environ.get", 1, {"default1", "default2"})
 
 
 class TestValuePatternExclusion:
     """Tests for value pattern-based exclusion."""
 
-    @pytest.fixture
-    def filter(self):
-        """Create filter instance."""
-        return FunctionCallFilter()
-
-    def test_excludes_numeric_strings(self, filter):
+    def test_excludes_numeric_strings(self):
         """Test that all-numeric string sets are excluded."""
-        assert not filter.should_include("func", 0, {"1", "2", "3"})
+        assert not context_filter.should_include("func", 0, {"1", "2", "3"})
 
-    def test_excludes_single_char_delimiters(self, filter):
+    def test_excludes_single_char_delimiters(self):
         """Test that single character delimiters are excluded."""
-        assert not filter.should_include("func", 0, {",", ";", ":"})
+        assert not context_filter.should_include("func", 0, {",", ";", ":"})
 
-    def test_excludes_http_methods(self, filter):
+    def test_excludes_http_methods(self):
         """Test that HTTP methods are excluded."""
-        assert not filter.should_include("func", 0, {"GET", "POST", "PUT"})
+        assert not context_filter.should_include("func", 0, {"GET", "POST", "PUT"})
 
-    def test_excludes_strftime_formats(self, filter):
+    def test_excludes_strftime_formats(self):
         """Test that strftime format strings are excluded."""
-        assert not filter.should_include("func", 0, {"%Y", "%m", "%d"})
+        assert not context_filter.should_include("func", 0, {"%Y", "%m", "%d"})
 
-    def test_excludes_file_modes(self, filter):
+    def test_excludes_file_modes(self):
         """Test that file mode strings are excluded."""
         # Only multi-char modes are excluded to avoid false positives
-        assert not filter.should_include("func", 0, {"rb", "wb", "r+"})
+        assert not context_filter.should_include("func", 0, {"rb", "wb", "r+"})
 
-    def test_includes_mixed_values(self, filter):
+    def test_includes_mixed_values(self):
         """Test that mixed value sets are included."""
         # Not all values are excluded patterns, so should be included
-        assert filter.should_include("func", 0, {"active", "inactive"})
+        assert context_filter.should_include("func", 0, {"active", "inactive"})
 
-    def test_includes_domain_values(self, filter):
+    def test_includes_domain_values(self):
         """Test that domain-specific values are included."""
-        assert filter.should_include("func", 0, {"pending", "approved", "rejected"})
+        assert context_filter.should_include("func", 0, {"pending", "approved", "rejected"})
 
 
 class TestCombinedFiltering:
     """Tests for combined filtering scenarios."""
 
-    @pytest.fixture
-    def filter(self):
-        """Create filter instance."""
-        return FunctionCallFilter()
-
-    def test_valid_stringly_typed_pattern(self, filter):
+    def test_valid_stringly_typed_pattern(self):
         """Test that valid stringly-typed patterns are included."""
         # Custom function with domain values should be included
-        assert filter.should_include("validate_status", 0, {"active", "pending", "closed"})
+        assert context_filter.should_include("validate_status", 0, {"active", "pending", "closed"})
 
-    def test_excludes_framework_pattern(self, filter):
+    def test_excludes_framework_pattern(self):
         """Test that framework patterns are excluded."""
         # Pydantic field_validator should be excluded
-        assert not filter.should_include("field_validator", 0, {"field1", "field2"})
+        assert not context_filter.should_include("field_validator", 0, {"field1", "field2"})
 
-    def test_excludes_aws_cdk_pattern(self, filter):
+    def test_excludes_aws_cdk_pattern(self):
         """Test that AWS CDK patterns are excluded."""
-        assert not filter.should_include("logs.LogGroup", 0, {"group1", "group2"})
+        assert not context_filter.should_include("logs.LogGroup", 0, {"group1", "group2"})
 
-    def test_case_insensitive_matching(self, filter):
+    def test_case_insensitive_matching(self):
         """Test that function name matching is case-insensitive."""
-        assert not filter.should_include("Logger.INFO", 0, {"msg1", "msg2"})
+        assert not context_filter.should_include("Logger.INFO", 0, {"msg1", "msg2"})
 
-    def test_empty_values_excluded(self, filter):
+    def test_empty_values_excluded(self):
         """Test that empty value sets are excluded."""
-        assert not filter.should_include("func", 0, set())
+        assert not context_filter.should_include("func", 0, set())


### PR DESCRIPTION
## Summary
- Removed questionable SRP suppressions from 3 stateless classes by converting them to module-level functions
- `ContextAnalyzer` (magic_numbers): 14 pure methods -> functions
- `TokenHasher` (dry): 10 pure methods -> functions
- `FunctionCallFilter` (stringly_typed): 8 pure methods -> functions

These classes had empty `__init__` and all methods were pure (no `self` usage), making them essentially namespaces for functions. The SRP suppressions claimed complexity was needed, but the real fix was extracting to module-level functions.

## Background
This is the first phase of a suppression audit that identified classes with questionable SRP justifications. The pattern found was: classes with empty `__init__` suppressing SRP because they had "too many methods" - but all methods were pure functions that don't use any instance state.

## Changes
- `src/linters/magic_numbers/context_analyzer.py` - Class -> functions
- `src/linters/dry/token_hasher.py` - Class -> functions
- `src/linters/stringly_typed/context_filter.py` - Class -> functions
- Updated call sites in 5 files
- Updated test file to use module-level function syntax

Note: Added `stateless-class` suppression to `BaseTokenAnalyzer` since it's an intentional template method base class for polymorphism (subclasses override `_should_include_block`).

## Test plan
- [x] All 1211 tests pass
- [x] Pre-commit hooks pass (formatting, linting, security, complexity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)