### PR TITLE
chore: Publish v0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.14.0"
+version = "0.15.0"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.15.0
- Updated poetry.lock
- Updated README badges (version, tests, coverage)

## Published to
- PyPI: https://pypi.org/project/thailint/0.15.0/
- Docker Hub: https://hub.docker.com/r/washad/thailint

🤖 Generated with [Claude Code](https://claude.com/claude-code)