### PR TITLE
test(law-of-demeter): Add RED test corpus for LoD linter

### DIFF
--- a/tests/unit/linters/law_of_demeter/__init__.py
+++ b/tests/unit/linters/law_of_demeter/__init__.py
@@ -1,0 +1,19 @@
+"""
+Purpose: Test package for Law of Demeter linter
+
+Scope: Unit tests for LoD violation detection, filtering, and configuration
+
+Overview: Contains comprehensive test suite for the Law of Demeter linter including
+    tests for chain extraction, classification, all 9 false-positive filters, config
+    loading, integration tests, violation messages, and ignore directives. Uses inline
+    code fixtures derived from 23 real-world Python repos to validate both true-positive
+    detection and false-positive filtering accuracy.
+
+Dependencies: pytest, src.linters.law_of_demeter
+
+Exports: Test modules for each component
+
+Interfaces: Standard pytest test discovery
+
+Implementation: TDD red/green methodology - tests written before implementation
+"""

--- a/tests/unit/linters/law_of_demeter/conftest.py
+++ b/tests/unit/linters/law_of_demeter/conftest.py
@@ -1,0 +1,38 @@
+"""
+Purpose: Pytest configuration for Law of Demeter test directory
+
+Scope: Skip test collection when implementation module is not yet available
+
+Overview: Uses pytest_ignore_collect hook to prevent collection errors for RED tests
+    that import from src.linters.law_of_demeter (not yet implemented). Once the
+    implementation module exists, this hook stops skipping and tests run normally.
+
+Dependencies: pytest
+
+Exports: pytest_ignore_collect hook
+
+Interfaces: Standard pytest conftest hook
+
+Implementation: Tries importing src.linters.law_of_demeter; skips test_*.py collection
+    on ImportError
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def pytest_ignore_collect(collection_path: Path, config: Any) -> bool | None:
+    """Skip LoD test collection when implementation module does not exist yet."""
+    try:
+        import src.linters.law_of_demeter  # noqa: F401
+
+        return None
+    except ImportError:
+        if collection_path.suffix == ".py" and collection_path.name.startswith("test_"):
+            # Skip fixture files in subdirectories — they have no actual tests
+            if "fixtures" in collection_path.parts:
+                return None
+            return True
+    return None

--- a/tests/unit/linters/law_of_demeter/fixtures/__init__.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/__init__.py
@@ -1,0 +1,17 @@
+"""
+Purpose: Test fixtures package for Law of Demeter linter tests
+
+Scope: Inline code samples for true-positive and false-positive test cases
+
+Overview: Contains Python and TypeScript code samples derived from real-world repos
+    (Flask, httpx, pydantic, Django, pandas, etc.) used to validate LoD violation
+    detection accuracy and false-positive filtering.
+
+Dependencies: None (pure string constants)
+
+Exports: Python and TypeScript sample modules
+
+Interfaces: Import string constants from submodules
+
+Implementation: String constants organized by source repo and violation type
+"""

--- a/tests/unit/linters/law_of_demeter/fixtures/python_samples/__init__.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/python_samples/__init__.py
@@ -1,0 +1,17 @@
+"""
+Purpose: Python code sample fixtures for Law of Demeter tests
+
+Scope: Inline Python code strings representing true and false positives
+
+Overview: Aggregates Python code samples from individual repo fixture files. Each
+    fixture module contains string constants with real-world code patterns that
+    exercise specific aspects of the LoD violation detection and filtering pipeline.
+
+Dependencies: None
+
+Exports: Re-exports from individual fixture modules
+
+Interfaces: Import string constants by category
+
+Implementation: One module per source repo or pattern category
+"""

--- a/tests/unit/linters/law_of_demeter/fixtures/python_samples/test_false_positives.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/python_samples/test_false_positives.py
@@ -1,0 +1,256 @@
+"""
+Purpose: False positive code samples for Law of Demeter filter testing
+
+Scope: Python code patterns that should NOT be flagged as LoD violations
+
+Overview: Contains inline Python code strings representing chains that look like LoD violations
+    by depth but are legitimate patterns. Each sample maps to one of the 9 classifier filters.
+    Derived from patterns observed in Flask, httpx, pydantic, Django, pandas, scikit-learn,
+    SQLAlchemy, and other real-world codebases during prototype testing.
+
+Dependencies: None (pure string constants)
+
+Exports: String constants for false-positive test cases grouped by filter category
+
+Interfaces: Import constants by name or filter category
+
+Implementation: Each constant is a complete Python code snippet parseable by ast.parse()
+"""
+
+# =============================================================================
+# FILTER 1: Safe prefix (self., cls., config., etc.)
+# =============================================================================
+
+SELF_ATTRIBUTE_ACCESS = """
+class MyClass:
+    def method(self):
+        return self.config.database.host
+"""
+
+CLS_ATTRIBUTE_ACCESS = """
+class MyClass:
+    @classmethod
+    def factory(cls):
+        return cls.defaults.connection.timeout
+"""
+
+SETTINGS_ACCESS = """
+def configure(settings):
+    host = settings.database.connection.host
+"""
+
+CONFIG_ACCESS = """
+def setup(config):
+    timeout = config.http.client.timeout
+"""
+
+LOGGER_CHAIN = """
+import logging
+def do_work():
+    logging.getLogger("app").handlers[0].setLevel(10)
+"""
+
+REQUEST_DATA_ACCESS = """
+def handle(request):
+    value = request.POST.get("key").strip()
+"""
+
+# =============================================================================
+# FILTER 2: Module-qualified access (import-aware)
+# =============================================================================
+
+OS_PATH_ACCESS = """
+import os
+def get_home():
+    return os.path.expanduser("~").strip()
+"""
+
+STDLIB_MODULE_CHAIN = """
+import json
+def parse(text):
+    return json.loads(text).get("key").upper()
+"""
+
+THIRD_PARTY_MODULE = """
+import flask
+def create_app():
+    return flask.Flask(__name__).register_blueprint(bp)
+"""
+
+FROM_IMPORT_MODULE = """
+from pathlib import Path
+def resolve(p):
+    return Path(p).resolve().parent.name
+"""
+
+DATETIME_MODULE = """
+import datetime
+def now_str():
+    return datetime.datetime.now().isoformat().split("T")[0]
+"""
+
+NUMPY_MODULE = """
+import numpy as np
+def compute(arr):
+    return np.array(arr).reshape(-1, 1).tolist()
+"""
+
+# =============================================================================
+# FILTER 3: Same-type string/bytes chaining
+# =============================================================================
+
+STRING_METHOD_CHAIN = """
+def clean(text):
+    return text.strip().lower().replace("-", "_")
+"""
+
+STRING_SPLIT_AND_PROCESS = """
+def parse_version(version):
+    return version.partition("+")[0].split(".")
+"""
+
+STRING_ATTR_THEN_METHODS = """
+def get_clean_name(node):
+    return node.name.strip().lower()
+"""
+
+REGEX_GROUP_CHAIN = """
+import re
+def extract(pattern, text):
+    m = re.match(pattern, text)
+    return m.group(1).strip().upper()
+"""
+
+# =============================================================================
+# FILTER 4: Fluent/builder/collection pipeline
+# =============================================================================
+
+ORM_QUERY_CHAIN = """
+def get_active_users(db):
+    return db.query(User).filter(active=True).order_by("name").limit(10)
+"""
+
+BUILDER_PATTERN = """
+def build_config(builder):
+    return builder.set("host", "localhost").set("port", 8080).build()
+"""
+
+DJANGO_QUERYSET = """
+def get_posts(request):
+    return Post.objects.filter(published=True).exclude(draft=True).order_by("-date")
+"""
+
+PANDAS_PIPELINE = """
+def transform(df):
+    return df.filter(items=["a", "b"]).groupby("a").sum()
+"""
+
+# =============================================================================
+# FILTER 5: AST / compiler node traversal
+# =============================================================================
+
+AST_NODE_WALK = """
+import ast
+def get_func_name(node):
+    return node.func.value.attr
+"""
+
+AST_DEEP_TRAVERSAL = """
+def extract_target(node):
+    return node.targets[0].value.id
+"""
+
+MYPY_NODE_ACCESS = """
+def get_type_info(node):
+    return node.callee.node.fullname
+"""
+
+# =============================================================================
+# FILTER 6: Dunder / protocol access
+# =============================================================================
+
+DUNDER_CLASS_ACCESS = """
+def get_class_name(obj):
+    return obj.__class__.__name__.lower()
+"""
+
+DUNDER_MODULE_ACCESS = """
+def get_module(func):
+    return func.__module__.__class__.__name__
+"""
+
+# =============================================================================
+# FILTER 7: Subscript-heavy chains
+# =============================================================================
+
+DICT_NAVIGATION = """
+def get_nested(data):
+    return data["config"]["database"]["host"]
+"""
+
+LIST_INDEX_ACCESS = """
+def first_word(lines):
+    return lines[0].split()[0].strip()
+"""
+
+SUBSCRIPT_WITH_ATTR = """
+def get_header(response):
+    return response.headers["Content-Type"].split(";")[0]
+"""
+
+# =============================================================================
+# FILTER 8: Safe terminal methods
+# =============================================================================
+
+ENDS_WITH_ITEMS = """
+def get_entries(registry):
+    return registry.store.data.items()
+"""
+
+ENDS_WITH_EXISTS = """
+def check_file(project):
+    return project.root.config_path.exists()
+"""
+
+ENDS_WITH_ENCODE = """
+def to_bytes(record):
+    return record.payload.body.encode()
+"""
+
+ENDS_WITH_TO_DICT = """
+def serialize(model):
+    return model.instance.data.to_dict()
+"""
+
+# =============================================================================
+# FILTER 9: Test file leniency
+# =============================================================================
+
+TEST_ASSERTION_CHAIN = """
+def test_response_body(client):
+    assert client.get("/api").json()["data"].get("id") == 1
+"""
+
+TEST_MOCK_CHAIN = """
+def test_setup(mocker):
+    mocker.patch("module.Class").return_value.method.return_value = 42
+"""
+
+# =============================================================================
+# PASSING (depth < 3, should never be flagged)
+# =============================================================================
+
+SIMPLE_ATTRIBUTE = """
+def get_name(user):
+    return user.name
+"""
+
+TWO_DEEP_CHAIN = """
+def get_city(user):
+    return user.address.city
+"""
+
+SINGLE_METHOD_CALL = """
+def process(data):
+    return data.transform()
+"""

--- a/tests/unit/linters/law_of_demeter/fixtures/python_samples/test_true_positives.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/python_samples/test_true_positives.py
@@ -1,0 +1,84 @@
+"""
+Purpose: True positive code samples for Law of Demeter violation detection
+
+Scope: Python code patterns that ARE genuine LoD violations
+
+Overview: Contains inline Python code strings representing real Law of Demeter violations
+    where an object reaches through intermediate objects to access deeply nested state.
+    These samples should all be flagged by the linter. Derived from patterns observed in
+    real-world codebases during prototype testing across 23 repos.
+
+Dependencies: None (pure string constants)
+
+Exports: String constants for true-positive test cases
+
+Interfaces: Import constants by name
+
+Implementation: Each constant is a complete Python code snippet parseable by ast.parse()
+"""
+
+# -- Reaching through objects to access nested state --
+
+REACH_THROUGH_NESTED_OBJECT = """
+def process_order(order):
+    name = order.customer.address.city
+"""
+
+REACH_THROUGH_METHOD_RESULT = """
+def get_info(service):
+    data = service.get_client().fetch_data().parse()
+"""
+
+MULTIPLE_VIOLATIONS_IN_FUNCTION = """
+def complex_handler(request):
+    user_city = request.user.profile.address.city
+    manager_name = request.department.manager.full_name
+"""
+
+CHAIN_WITH_MIXED_ATTR_AND_CALLS = """
+def handle_event(event):
+    result = event.get_source().get_handler().process()
+"""
+
+DEEP_ATTRIBUTE_ONLY_CHAIN = """
+def render_template(ctx):
+    title = ctx.page.header.title.text
+"""
+
+VIOLATION_IN_ASSIGNMENT = """
+def save_record(db):
+    table = db.engine.connection.cursor
+"""
+
+VIOLATION_IN_CONDITIONAL = """
+def check_status(app):
+    if app.server.connection.is_active:
+        pass
+"""
+
+VIOLATION_IN_RETURN = """
+def get_name(company):
+    return company.department.head.name
+"""
+
+VIOLATION_IN_CALL_ARGUMENT = """
+def log_info(system):
+    print(system.network.adapter.mac_address)
+"""
+
+VIOLATION_IN_LOOP = """
+def process_items(registry):
+    for item in registry.store.shelf.items:
+        pass
+"""
+
+VIOLATION_WITH_METHOD_CALL_MID_CHAIN = """
+def transform(pipeline):
+    output = pipeline.stage.get_transformer().run()
+"""
+
+VIOLATION_CLASS_METHOD = """
+class Handler:
+    def handle(self, ctx):
+        name = ctx.request.user.profile.display_name
+"""

--- a/tests/unit/linters/law_of_demeter/fixtures/typescript_samples/__init__.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/typescript_samples/__init__.py
@@ -1,0 +1,17 @@
+"""
+Purpose: TypeScript code sample fixtures for Law of Demeter tests
+
+Scope: Inline TypeScript code strings representing true and false positives
+
+Overview: Contains TypeScript code samples for testing LoD chain detection in
+    TypeScript via tree-sitter. Covers React, Express, and general TypeScript
+    patterns including optional chaining, module-qualified access, and fluent APIs.
+
+Dependencies: None
+
+Exports: String constants for TypeScript test patterns
+
+Interfaces: Import string constants by category
+
+Implementation: String constants organized by pattern type
+"""

--- a/tests/unit/linters/law_of_demeter/fixtures/typescript_samples/test_samples.py
+++ b/tests/unit/linters/law_of_demeter/fixtures/typescript_samples/test_samples.py
@@ -1,0 +1,94 @@
+"""
+Purpose: TypeScript code sample fixtures for Law of Demeter tests
+
+Scope: TypeScript code patterns for true-positive and false-positive LoD testing
+
+Overview: Contains inline TypeScript code strings representing both genuine LoD violations
+    and legitimate chain patterns (fluent APIs, module-qualified access, optional chaining).
+    Used to test tree-sitter-based TypeScript analyzer. Covers React, Express, lodash, zod,
+    and general TypeScript patterns.
+
+Dependencies: None (pure string constants)
+
+Exports: String constants for TypeScript test cases
+
+Interfaces: Import constants by name
+
+Implementation: Each constant is a complete TypeScript code snippet parseable by tree-sitter
+"""
+
+# =============================================================================
+# TRUE POSITIVES - genuine LoD violations in TypeScript
+# =============================================================================
+
+TS_REACH_THROUGH_OBJECT = """
+function processOrder(order: Order) {
+    const city = order.customer.address.city;
+}
+"""
+
+TS_METHOD_CHAIN_VIOLATION = """
+function getData(service: Service) {
+    return service.getClient().fetchData().parse();
+}
+"""
+
+TS_DEEP_PROPERTY_ACCESS = """
+function renderTitle(ctx: Context) {
+    return ctx.page.header.title.text;
+}
+"""
+
+# =============================================================================
+# FALSE POSITIVES - should be filtered
+# =============================================================================
+
+# Module-qualified access
+TS_MODULE_ACCESS = """
+import express from 'express';
+const app = express.Router().use(middleware).get('/');
+"""
+
+# Fluent API / builder
+TS_FLUENT_BUILDER = """
+function buildQuery(db: Database) {
+    return db.select('*').where('active', true).orderBy('name').limit(10);
+}
+"""
+
+# Optional chaining (should be allowed by default)
+TS_OPTIONAL_CHAIN = """
+function getCity(user?: User) {
+    return user?.address?.city?.name;
+}
+"""
+
+# String method chaining
+TS_STRING_CHAIN = """
+function clean(text: string) {
+    return text.trim().toLowerCase().replace(/-/g, '_');
+}
+"""
+
+# React pattern - safe prefix (this.)
+TS_REACT_THIS = """
+class MyComponent extends React.Component {
+    render() {
+        return this.props.config.theme.color;
+    }
+}
+"""
+
+# Promise chaining (fluent)
+TS_PROMISE_CHAIN = """
+function fetchData(url: string) {
+    return fetch(url).then(r => r.json()).then(data => data.result);
+}
+"""
+
+# Array method pipeline
+TS_ARRAY_PIPELINE = """
+function transform(items: Item[]) {
+    return items.filter(x => x.active).map(x => x.name).join(', ');
+}
+"""

--- a/tests/unit/linters/law_of_demeter/test_chain_classifier.py
+++ b/tests/unit/linters/law_of_demeter/test_chain_classifier.py
@@ -1,0 +1,99 @@
+"""
+Purpose: Test classify_chain() orchestration across all filters
+
+Scope: End-to-end chain classification with filter pipeline ordering
+
+Overview: Validates the classify_chain() function that orchestrates the 9-filter pipeline.
+    Tests verify that the correct filter fires for each category, that filter ordering is
+    respected (earlier filters take precedence), and that genuine violations return an
+    empty string. Uses a mix of true-positive and false-positive chain patterns.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestClassifyChainOrchestration (8 tests)
+
+Interfaces: Tests classify_chain(parts, imports, filepath) -> str
+
+Implementation: Calls classify_chain() with various chain patterns, verifies
+    correct filter identification or empty string for violations
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestClassifyChainOrchestration:
+    """Test classify_chain() filter pipeline orchestration."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_violation_returns_empty_string(self) -> None:
+        """Genuine violation should return empty string."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result == ""
+
+    def test_safe_prefix_takes_precedence(self) -> None:
+        """Safe prefix should be checked before module access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        # self. chains are safe prefix, not module access
+        parts = ["self", "os", "path", "join()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")
+
+    def test_module_access_recognized(self) -> None:
+        """Module-rooted chain should be identified."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        imports.module_names.add("os")
+        parts = ["os", "path", "join()", "strip()"]
+        result = classify_chain(parts, imports, "app.py")
+        assert result.startswith("module-access")
+
+    def test_string_chain_recognized(self) -> None:
+        """String method chain should be identified."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["text", "strip()", "lower()", "replace()"]
+        result = classify_chain(parts, self._empty_imports(), "utils.py")
+        assert "same-type:str" in result
+
+    def test_fluent_chain_recognized(self) -> None:
+        """Fluent/builder chain should be identified."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["db", "filter()", "order_by()", "limit()"]
+        result = classify_chain(parts, self._empty_imports(), "views.py")
+        assert result == "fluent-chain"
+
+    def test_dunder_recognized(self) -> None:
+        """Dunder access should be identified."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["obj", "__class__", "__name__", "lower()"]
+        result = classify_chain(parts, self._empty_imports(), "utils.py")
+        assert result == "dunder-access"
+
+    def test_test_file_last_resort(self) -> None:
+        """Test file filter fires as last resort for non-safe chains."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        # A chain that doesn't match any other filter
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "test_orders.py")
+        assert result == "test-file"
+
+    def test_multiple_filters_first_wins(self) -> None:
+        """When multiple filters could match, first in pipeline wins."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        # self. prefix AND ends with items() - safe-prefix should win
+        parts = ["self", "data", "store", "items()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")

--- a/tests/unit/linters/law_of_demeter/test_chain_extractor.py
+++ b/tests/unit/linters/law_of_demeter/test_chain_extractor.py
@@ -1,0 +1,144 @@
+"""
+Purpose: Test chain_to_parts() function for AST chain extraction
+
+Scope: Converting AST Attribute/Call/Subscript nodes into list[str] chain parts
+
+Overview: Validates the chain_to_parts() function that walks AST nodes and extracts
+    chain parts like ["obj", "method()", "attr"]. Tests cover simple attribute chains,
+    method calls, mixed chains, subscript access, nested calls, and edge cases like
+    bare function calls and chained calls without attributes.
+
+Dependencies: pytest, ast, src.linters.law_of_demeter.chain_extractor
+
+Exports: TestChainToParts (10 tests), TestChainHelpers (3 tests) - total 13 test cases
+
+Interfaces: Tests chain_to_parts(node) -> list[str]
+
+Implementation: Parses Python code strings via ast.parse(), walks to target nodes,
+    calls chain_to_parts(), and verifies resulting part lists
+"""
+
+import ast
+
+
+class TestChainToParts:
+    """Test chain_to_parts() for various AST shapes."""
+
+    def test_simple_attribute_chain(self) -> None:
+        """Should extract parts from a.b.c."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b.c")
+        # Find the outermost Attribute node
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["a", "b", "c"]
+
+    def test_method_call_chain(self) -> None:
+        """Should mark method calls with () in a.b().c."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b().c")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["a", "b()", "c"]
+
+    def test_chained_calls(self) -> None:
+        """Should handle a.b().c().d."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b().c().d")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["a", "b()", "c()", "d"]
+
+    def test_subscript_in_chain(self) -> None:
+        """Should represent subscripts as [...] in a[0].b.c."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a[0].b.c")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        # Should have subscript marker
+        assert "[" in "".join(parts) or len(parts) >= 3
+
+    def test_bare_name(self) -> None:
+        """Should handle a single name node."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("x")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["x"]
+
+    def test_call_at_end(self) -> None:
+        """Should handle a.b.c() with call at end."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b.c()")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["a", "b", "c()"]
+
+    def test_call_at_start(self) -> None:
+        """Should handle f().b.c where root is a call."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("f().b.c")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts[0] == "f()"
+        assert parts[-1] == "c"
+
+    def test_deeply_nested_chain(self) -> None:
+        """Should handle a.b.c.d.e (5 parts)."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b.c.d.e")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts == ["a", "b", "c", "d", "e"]
+
+    def test_mixed_calls_and_attrs(self) -> None:
+        """Should handle a.b().c.d().e pattern."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a.b().c.d().e")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert len(parts) == 5
+        assert parts[1] == "b()"
+        assert parts[3] == "d()"
+
+    def test_double_subscript(self) -> None:
+        """Should handle a[0][1].b."""
+        from src.linters.law_of_demeter.chain_extractor import chain_to_parts
+
+        tree = ast.parse("a[0][1].b")
+        node = tree.body[0].value  # type: ignore[union-attr]
+        parts = chain_to_parts(node)
+        assert parts[-1] == "b"
+
+
+class TestChainHelpers:
+    """Test helper functions for chain part analysis."""
+
+    def test_clean_strips_call_marker(self) -> None:
+        """Should strip () from chain parts."""
+        from src.linters.law_of_demeter.chain_extractor import clean_part
+
+        assert clean_part("method()") == "method"
+
+    def test_clean_strips_subscript_marker(self) -> None:
+        """Should strip [...] from chain parts."""
+        from src.linters.law_of_demeter.chain_extractor import clean_part
+
+        result = clean_part("[\\u2026]")
+        assert "[" not in result
+
+    def test_is_subscript_detects_subscript(self) -> None:
+        """Should detect subscript parts."""
+        from src.linters.law_of_demeter.chain_extractor import is_subscript_part
+
+        assert is_subscript_part("[\\u2026]") is True
+        assert is_subscript_part("method()") is False

--- a/tests/unit/linters/law_of_demeter/test_config.py
+++ b/tests/unit/linters/law_of_demeter/test_config.py
@@ -1,0 +1,117 @@
+"""
+Purpose: Test configuration loading for Law of Demeter linter
+
+Scope: LawOfDemeterConfig dataclass, from_dict(), defaults, validation
+
+Overview: Validates configuration loading and validation for the Law of Demeter linter including
+    default min_chain_depth value (3), custom limits loaded from config dicts, invalid config
+    rejection, enabled/disabled behavior, safe_prefixes/fluent_methods/exempt_modules list
+    merging, and check_test_files toggle. Ensures configuration system provides flexible
+    control over LoD detection while maintaining sensible defaults.
+
+Dependencies: pytest, src.linters.law_of_demeter.config for LawOfDemeterConfig
+
+Exports: TestConfigDefaults (4 tests), TestConfigFromDict (4 tests),
+    TestConfigValidation (3 tests) - total 11 test cases
+
+Interfaces: Tests LawOfDemeterConfig dataclass and LawOfDemeterConfig.from_dict()
+
+Implementation: Creates config instances directly and via from_dict(), verifies defaults,
+    custom values, validation errors, and list merging behavior
+"""
+
+import pytest
+
+
+class TestConfigDefaults:
+    """Test default configuration values."""
+
+    def test_default_min_chain_depth(self) -> None:
+        """Should default min_chain_depth to 3."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig()
+        assert config.min_chain_depth == 3
+
+    def test_default_enabled(self) -> None:
+        """Should default enabled to True."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig()
+        assert config.enabled is True
+
+    def test_default_check_test_files(self) -> None:
+        """Should default check_test_files to False."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig()
+        assert config.check_test_files is False
+
+    def test_default_lists_not_empty(self) -> None:
+        """Should have non-empty default safe_prefixes and fluent_methods."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig()
+        assert len(config.safe_prefixes) > 0
+        assert len(config.fluent_methods) > 0
+
+
+class TestConfigFromDict:
+    """Test config loading from dictionary."""
+
+    def test_from_dict_with_defaults(self) -> None:
+        """Should use defaults when dict is empty."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig.from_dict({})
+        assert config.min_chain_depth == 3
+        assert config.enabled is True
+
+    def test_from_dict_with_custom_depth(self) -> None:
+        """Should respect custom min_chain_depth."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig.from_dict({"min_chain_depth": 4})
+        assert config.min_chain_depth == 4
+
+    def test_from_dict_disabled(self) -> None:
+        """Should respect enabled: false."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig.from_dict({"enabled": False})
+        assert config.enabled is False
+
+    def test_from_dict_merges_safe_prefixes(self) -> None:
+        """Should merge user safe_prefixes with defaults."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        config = LawOfDemeterConfig.from_dict({"safe_prefixes": ["custom."]})
+        # Should contain both defaults and custom
+        assert "custom." in config.safe_prefixes
+        assert "self." in config.safe_prefixes
+
+
+class TestConfigValidation:
+    """Test config validation."""
+
+    def test_rejects_zero_depth(self) -> None:
+        """Should reject min_chain_depth of 0."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        with pytest.raises(ValueError):
+            LawOfDemeterConfig(min_chain_depth=0)
+
+    def test_rejects_negative_depth(self) -> None:
+        """Should reject negative min_chain_depth."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        with pytest.raises(ValueError):
+            LawOfDemeterConfig(min_chain_depth=-1)
+
+    def test_accepts_valid_depths(self) -> None:
+        """Should accept positive min_chain_depth values."""
+        from src.linters.law_of_demeter.config import LawOfDemeterConfig
+
+        for depth in [1, 2, 3, 5, 10]:
+            config = LawOfDemeterConfig(min_chain_depth=depth)
+            assert config.min_chain_depth == depth

--- a/tests/unit/linters/law_of_demeter/test_filter_ast_traversal.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_ast_traversal.py
@@ -1,0 +1,62 @@
+"""
+Purpose: Test AST traversal filter for Law of Demeter classifier
+
+Scope: Filtering chains that navigate AST/compiler node attributes
+
+Overview: Validates the AST traversal filter that allows chains consisting primarily of
+    AST node attribute names (func, value, attr, args, body, targets, etc.). These chains
+    navigate data structures (like compiler ASTs) rather than violating encapsulation.
+    The filter fires when >= 60% of intermediate parts are known AST node attributes.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestAstTraversalFilter (4 tests)
+
+Interfaces: Tests classify_chain() returning "ast-traversal" for AST navigation chains
+
+Implementation: Calls classify_chain() with AST node attribute parts,
+    verifies ast-traversal filter fires when threshold met
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestAstTraversalFilter:
+    """Test AST/compiler node traversal filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_ast_node_chain(self) -> None:
+        """node.func.value.attr should be ast-traversal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["node", "func", "value", "attr"]
+        result = classify_chain(parts, self._empty_imports(), "analyzer.py")
+        assert result == "ast-traversal"
+
+    def test_ast_target_chain(self) -> None:
+        """node.targets[0].value.id should be ast-traversal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["node", "targets", "[\u2026]", "value", "id"]
+        result = classify_chain(parts, self._empty_imports(), "compiler.py")
+        assert result == "ast-traversal"
+
+    def test_mypy_node_access(self) -> None:
+        """node.callee.node.fullname should be ast-traversal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["node", "callee", "node", "fullname"]
+        result = classify_chain(parts, self._empty_imports(), "type_checker.py")
+        assert result == "ast-traversal"
+
+    def test_non_ast_chain_not_filtered(self) -> None:
+        """Chain with non-AST attributes should not be caught."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result != "ast-traversal"

--- a/tests/unit/linters/law_of_demeter/test_filter_dunder.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_dunder.py
@@ -1,0 +1,61 @@
+"""
+Purpose: Test dunder-access filter for Law of Demeter classifier
+
+Scope: Filtering chains containing dunder (double-underscore) protocol attributes
+
+Overview: Validates the dunder-access filter that allows chains containing Python protocol
+    attributes like __class__, __name__, __module__, etc. These access Python's object model
+    internals and are framework/protocol patterns, not encapsulation violations.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestDunderFilter (4 tests)
+
+Interfaces: Tests classify_chain() returning "dunder-access" for chains with dunder attrs
+
+Implementation: Calls classify_chain() with dunder attribute parts,
+    verifies dunder-access filter fires
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestDunderFilter:
+    """Test dunder/protocol access filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_class_name_access(self) -> None:
+        """obj.__class__.__name__.lower() should be dunder-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["obj", "__class__", "__name__", "lower()"]
+        result = classify_chain(parts, self._empty_imports(), "utils.py")
+        assert result == "dunder-access"
+
+    def test_module_access(self) -> None:
+        """func.__module__.__class__.__name__ should be dunder-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["func", "__module__", "__class__", "__name__"]
+        result = classify_chain(parts, self._empty_imports(), "inspect.py")
+        assert result == "dunder-access"
+
+    def test_single_dunder_in_chain(self) -> None:
+        """Even one dunder in chain should trigger filter."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["obj", "meta", "__class__", "name"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result == "dunder-access"
+
+    def test_no_dunder_not_filtered(self) -> None:
+        """Chain without dunder should not be caught by this filter."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result != "dunder-access"

--- a/tests/unit/linters/law_of_demeter/test_filter_fluent_chain.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_fluent_chain.py
@@ -1,0 +1,70 @@
+"""
+Purpose: Test fluent-chain filter for Law of Demeter classifier
+
+Scope: Filtering ORM queries, builder patterns, and collection pipelines
+
+Overview: Validates the fluent-chain filter that allows chains consisting entirely of
+    collection pipeline methods (filter, map, select, where, order_by, limit) or builder
+    methods (set, with_, add, configure, build). These are fluent APIs where each call
+    returns the same or similar type, not Law of Demeter violations.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestFluentChainFilter (5 tests)
+
+Interfaces: Tests classify_chain() returning "fluent-chain" for pipeline chains
+
+Implementation: Calls classify_chain() with ORM/builder chain parts,
+    verifies fluent-chain filter fires
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestFluentChainFilter:
+    """Test fluent-chain filter for ORM/builder/pipeline patterns."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_orm_query_chain(self) -> None:
+        """db.query().filter().order_by().limit() should be fluent-chain."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["db", "filter()", "order_by()", "limit()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result == "fluent-chain"
+
+    def test_builder_pattern(self) -> None:
+        """builder.set().set().build() should be fluent-chain."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["builder", "set()", "set()", "build()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result == "fluent-chain"
+
+    def test_django_queryset(self) -> None:
+        """Post.objects.filter().exclude().order_by() should be fluent-chain."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["Post", "filter()", "exclude()", "order_by()"]
+        result = classify_chain(parts, self._empty_imports(), "views.py")
+        assert result == "fluent-chain"
+
+    def test_pandas_pipeline(self) -> None:
+        """df.filter().groupby().sum() should be fluent-chain."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["df", "filter()", "groupby()", "sorted()"]
+        result = classify_chain(parts, self._empty_imports(), "analysis.py")
+        assert result == "fluent-chain"
+
+    def test_mixed_non_fluent_not_filtered(self) -> None:
+        """Chain with non-fluent methods should not be caught."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result != "fluent-chain"

--- a/tests/unit/linters/law_of_demeter/test_filter_module_access.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_module_access.py
@@ -1,0 +1,84 @@
+"""
+Purpose: Test module-access filter for Law of Demeter classifier
+
+Scope: Filtering chains that start with known module names (import-aware)
+
+Overview: Validates the module-access filter that allows chains rooted in module names.
+    Chains like os.path.expanduser().strip() or json.loads().get().upper() are module-qualified
+    access, not object navigation. The filter uses both known module roots (stdlib, common
+    third-party) and file-specific import tracking to identify module names.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestModuleAccessFilter (6 tests)
+
+Interfaces: Tests classify_chain() returning "module-access:*" for module-rooted chains
+
+Implementation: Creates FileImports with module names, calls classify_chain(),
+    verifies module-access filter fires for known modules and imported names
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestModuleAccessFilter:
+    """Test module-access filter identifies module-qualified chains."""
+
+    def test_stdlib_module_allowed(self) -> None:
+        """os.path.expanduser().strip() should be module-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        imports.module_names.add("os")
+        parts = ["os", "path", "expanduser()", "strip()"]
+        result = classify_chain(parts, imports, "app.py")
+        assert result.startswith("module-access")
+
+    def test_known_module_root_without_import(self) -> None:
+        """Known module roots should be recognized even without explicit import."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        parts = ["json", "loads()", "get()", "upper()"]
+        result = classify_chain(parts, imports, "app.py")
+        assert result.startswith("module-access")
+
+    def test_third_party_module(self) -> None:
+        """flask.Flask(__name__).register_blueprint() should be module-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        imports.module_names.add("flask")
+        parts = ["flask", "Flask()", "register_blueprint()"]
+        result = classify_chain(parts, imports, "app.py")
+        assert result.startswith("module-access")
+
+    def test_aliased_import(self) -> None:
+        """np.array().reshape().tolist() should be module-access when np imported."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        imports.module_names.add("np")
+        parts = ["np", "array()", "reshape()", "tolist()"]
+        result = classify_chain(parts, imports, "compute.py")
+        assert result.startswith("module-access")
+
+    def test_datetime_module(self) -> None:
+        """datetime.datetime.now().isoformat() should be module-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        imports.module_names.add("datetime")
+        parts = ["datetime", "datetime", "now()", "isoformat()"]
+        result = classify_chain(parts, imports, "utils.py")
+        assert result.startswith("module-access")
+
+    def test_non_module_not_filtered(self) -> None:
+        """Non-module rooted chains should not be caught by this filter."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        imports = FileImports()
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, imports, "app.py")
+        assert not result.startswith("module-access")

--- a/tests/unit/linters/law_of_demeter/test_filter_safe_prefix.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_safe_prefix.py
@@ -1,0 +1,79 @@
+"""
+Purpose: Test safe-prefix filter for Law of Demeter classifier
+
+Scope: Filtering chains starting with self., cls., config., settings., etc.
+
+Overview: Validates the safe-prefix filter that allows chains starting with known safe
+    prefixes like self., cls., settings., config., logger., request.POST., etc. These
+    chains access an object's own state or well-known namespace objects and are not LoD
+    violations. Tests cover all built-in safe prefixes and user-configured custom prefixes.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier
+
+Exports: TestSafePrefixFilter (6 tests)
+
+Interfaces: Tests classify_chain() returning "safe-prefix:*" for matching chains
+
+Implementation: Calls classify_chain() with chain parts starting with safe prefixes,
+    verifies the filter fires and returns appropriate reason string
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestSafePrefixFilter:
+    """Test safe-prefix filter catches self/cls/config/settings chains."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_self_prefix_allowed(self) -> None:
+        """Chains starting with self. should be allowed."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["self", "config", "database", "host"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")
+
+    def test_cls_prefix_allowed(self) -> None:
+        """Chains starting with cls. should be allowed."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["cls", "defaults", "connection", "timeout"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")
+
+    def test_settings_prefix_allowed(self) -> None:
+        """Chains starting with settings. should be allowed."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["settings", "database", "connection", "host"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")
+
+    def test_config_prefix_allowed(self) -> None:
+        """Chains starting with config. should be allowed."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["config", "http", "client", "timeout"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-prefix")
+
+    def test_request_data_prefix_allowed(self) -> None:
+        """Chains starting with request.POST. should be allowed."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["request", "POST", "get()", "strip()"]
+        result = classify_chain(parts, self._empty_imports(), "views.py")
+        assert result != ""  # Should be filtered
+
+    def test_non_safe_prefix_not_filtered(self) -> None:
+        """Chains not starting with safe prefix should not be filtered here."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        # This might be caught by another filter or be a violation
+        # But safe-prefix filter should NOT catch it
+        assert not result.startswith("safe-prefix")

--- a/tests/unit/linters/law_of_demeter/test_filter_string_chain.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_string_chain.py
@@ -1,0 +1,71 @@
+"""
+Purpose: Test string-chain filter for Law of Demeter classifier
+
+Scope: Filtering chains of string/bytes method calls (same-type chaining)
+
+Overview: Validates the same-type string filter that allows chains consisting of string
+    manipulation methods (strip, lower, upper, replace, split, join, etc.). These chains
+    always return the same type (str) and are not Law of Demeter violations. Also covers
+    the string-attr variant where the first step is an attribute access followed by string
+    methods (e.g., node.name.strip().lower()).
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestStringChainFilter (5 tests)
+
+Interfaces: Tests classify_chain() returning "same-type:str" or "same-type:str-attr"
+
+Implementation: Calls classify_chain() with string method chain parts,
+    verifies string-chain filter fires
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestStringChainFilter:
+    """Test same-type string method chain filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_pure_string_chain(self) -> None:
+        """text.strip().lower().replace() should be same-type:str."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["text", "strip()", "lower()", "replace()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert "same-type:str" in result
+
+    def test_split_and_process(self) -> None:
+        """version.partition()[0].split() should be same-type:str."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["version", "partition()", "[\u2026]", "split()"]
+        result = classify_chain(parts, self._empty_imports(), "utils.py")
+        assert "same-type" in result or result != ""
+
+    def test_attr_then_string_methods(self) -> None:
+        """node.name.strip().lower() should be same-type:str-attr."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["node", "name", "strip()", "lower()"]
+        result = classify_chain(parts, self._empty_imports(), "parser.py")
+        assert "same-type:str" in result
+
+    def test_regex_group_chain(self) -> None:
+        """m.group().strip().upper() should be same-type:str."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["m", "group()", "strip()", "upper()"]
+        result = classify_chain(parts, self._empty_imports(), "parser.py")
+        assert "same-type:str" in result
+
+    def test_non_string_methods_not_filtered(self) -> None:
+        """Chain with non-string methods should not be caught."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert "same-type:str" not in result

--- a/tests/unit/linters/law_of_demeter/test_filter_subscript.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_subscript.py
@@ -1,0 +1,63 @@
+"""
+Purpose: Test subscript-access filter for Law of Demeter classifier
+
+Scope: Filtering chains where most depth comes from subscript (dict/list) access
+
+Overview: Validates the subscript-access filter that allows chains where most of the
+    apparent depth comes from subscript operations (dict/list indexing) rather than
+    attribute access. Chains like data["config"]["database"]["host"] navigate data
+    structures, not object hierarchies, and are not LoD violations.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestSubscriptFilter (4 tests)
+
+Interfaces: Tests classify_chain() returning "subscript-access" for subscript-heavy chains
+
+Implementation: Calls classify_chain() with subscript marker parts,
+    verifies subscript-access filter fires when threshold met
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestSubscriptFilter:
+    """Test subscript-heavy chain filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_dict_navigation(self) -> None:
+        """data["config"]["database"]["host"] should be subscript-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["data", "[\u2026]", "[\u2026]", "[\u2026]"]
+        result = classify_chain(parts, self._empty_imports(), "config.py")
+        assert result == "subscript-access"
+
+    def test_list_then_attr(self) -> None:
+        """lines[0].split()[0] should be subscript-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["lines", "[\u2026]", "split()", "[\u2026]"]
+        result = classify_chain(parts, self._empty_imports(), "parser.py")
+        assert result == "subscript-access"
+
+    def test_single_subscript_with_short_chain(self) -> None:
+        """response.headers["Content-Type"] with 1 subscript + 1 attr = subscript-access."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["response", "headers", "[\u2026]"]
+        result = classify_chain(parts, self._empty_imports(), "http.py")
+        # Short chain, but subscript filter should still recognize the pattern
+        assert result == "subscript-access"
+
+    def test_deep_attr_chain_not_filtered(self) -> None:
+        """Chain without subscripts should not be caught by this filter."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result != "subscript-access"

--- a/tests/unit/linters/law_of_demeter/test_filter_terminal.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_terminal.py
@@ -1,0 +1,71 @@
+"""
+Purpose: Test safe-terminal filter for Law of Demeter classifier
+
+Scope: Filtering chains ending with known safe terminal methods
+
+Overview: Validates the safe-terminal filter that allows chains ending with commonly used
+    terminal methods like items(), keys(), values(), exists(), encode(), to_dict(), etc.
+    These methods are ubiquitous endpoints that provide standard conversions or lookups
+    and rarely indicate encapsulation violations even when the chain is deep.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestTerminalFilter (5 tests)
+
+Interfaces: Tests classify_chain() returning "safe-terminal:*" for chains ending with
+    known terminal methods
+
+Implementation: Calls classify_chain() with chains ending in safe terminals,
+    verifies safe-terminal filter fires
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestTerminalFilter:
+    """Test safe-terminal method filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_ends_with_items(self) -> None:
+        """registry.store.data.items() should be safe-terminal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["registry", "store", "data", "items()"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result.startswith("safe-terminal")
+
+    def test_ends_with_exists(self) -> None:
+        """project.root.config_path.exists() should be safe-terminal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["project", "root", "config_path", "exists()"]
+        result = classify_chain(parts, self._empty_imports(), "setup.py")
+        assert result.startswith("safe-terminal")
+
+    def test_ends_with_encode(self) -> None:
+        """record.payload.body.encode() should be safe-terminal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["record", "payload", "body", "encode()"]
+        result = classify_chain(parts, self._empty_imports(), "serializer.py")
+        assert result.startswith("safe-terminal")
+
+    def test_ends_with_to_dict(self) -> None:
+        """model.instance.data.to_dict() should be safe-terminal."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["model", "instance", "data", "to_dict()"]
+        result = classify_chain(parts, self._empty_imports(), "api.py")
+        assert result.startswith("safe-terminal")
+
+    def test_non_terminal_not_filtered(self) -> None:
+        """Chain ending with non-terminal should not be caught."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert not result.startswith("safe-terminal")

--- a/tests/unit/linters/law_of_demeter/test_filter_test_file.py
+++ b/tests/unit/linters/law_of_demeter/test_filter_test_file.py
@@ -1,0 +1,61 @@
+"""
+Purpose: Test test-file filter for Law of Demeter classifier
+
+Scope: Filtering chains in test files (check_test_files=false by default)
+
+Overview: Validates the test-file filter that allows chains in test files when
+    check_test_files is false (default). Test code commonly has deep assertion
+    chains and mock setup chains that aren't actionable LoD violations.
+
+Dependencies: pytest, src.linters.law_of_demeter.chain_classifier,
+    src.linters.law_of_demeter.python_analyzer
+
+Exports: TestTestFileFilter (4 tests)
+
+Interfaces: Tests classify_chain() returning "test-file" for chains in test files
+
+Implementation: Calls classify_chain() with test file paths,
+    verifies test-file filter fires based on file path patterns
+"""
+
+from src.linters.law_of_demeter.python_analyzer import FileImports
+
+
+class TestTestFileFilter:
+    """Test test-file leniency filter."""
+
+    def _empty_imports(self) -> FileImports:
+        """Create empty imports for testing."""
+        return FileImports()
+
+    def test_test_prefix_file(self) -> None:
+        """Chains in test_*.py files should be filtered."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["client", "get()", "json()", "data"]
+        result = classify_chain(parts, self._empty_imports(), "test_api.py")
+        assert result == "test-file"
+
+    def test_tests_directory(self) -> None:
+        """Chains in tests/ directory should be filtered."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["mocker", "patch()", "return_value", "method"]
+        result = classify_chain(parts, self._empty_imports(), "tests/test_service.py")
+        assert result == "test-file"
+
+    def test_conftest_file(self) -> None:
+        """Chains in conftest.py should be filtered."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["fixture", "setup", "mock", "value"]
+        result = classify_chain(parts, self._empty_imports(), "conftest.py")
+        assert result == "test-file"
+
+    def test_non_test_file_not_filtered(self) -> None:
+        """Chains in regular files should not be caught by test filter."""
+        from src.linters.law_of_demeter.chain_classifier import classify_chain
+
+        parts = ["order", "customer", "address", "city"]
+        result = classify_chain(parts, self._empty_imports(), "app.py")
+        assert result != "test-file"

--- a/tests/unit/linters/law_of_demeter/test_ignore_directives.py
+++ b/tests/unit/linters/law_of_demeter/test_ignore_directives.py
@@ -1,0 +1,85 @@
+"""
+Purpose: Test inline ignore directives for Law of Demeter violations
+
+Scope: Inline comments to suppress LoD warnings using thailint ignore syntax
+
+Overview: Validates inline ignore directive functionality for suppressing Law of Demeter
+    violations through special comments. Tests verify violations can be suppressed with
+    rule-specific inline comments (# thailint: ignore law-of-demeter), supports ignore-all
+    directive, and respects rule-specific ignores (law-of-demeter vs other rules).
+
+Dependencies: pytest, src.linters.law_of_demeter.linter, pathlib, unittest.mock
+
+Exports: TestIgnoreDirectives (4 tests)
+
+Interfaces: Tests inline comment parsing and violation suppression in
+    LawOfDemeterRule.check()
+
+Implementation: Uses code samples with ignore comments, verifies violations are
+    suppressed or reported based on ignore directive presence
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+
+def _create_python_context(code: str, filename: str = "app.py") -> Mock:
+    """Create mock lint context for Python code."""
+    context = Mock()
+    context.file_content = code
+    context.file_path = Path(filename)
+    context.language = "python"
+    context.metadata = {}
+    return context
+
+
+class TestIgnoreDirectives:
+    """Test inline ignore directives for LoD linter."""
+
+    def test_ignore_all_suppresses(self) -> None:
+        """# thailint: ignore-all should suppress LoD violations."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():  # thailint: ignore-all
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_ignore_specific_rule_suppresses(self) -> None:
+        """# thailint: ignore law-of-demeter should suppress LoD violations."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d  # thailint: ignore law-of-demeter
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_ignore_wrong_rule_doesnt_suppress(self) -> None:
+        """# thailint: ignore other-rule should NOT suppress LoD violations."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d  # thailint: ignore nesting
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+
+    def test_no_ignore_reports_violation(self) -> None:
+        """Without ignore directive, violations should be reported."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1

--- a/tests/unit/linters/law_of_demeter/test_integration.py
+++ b/tests/unit/linters/law_of_demeter/test_integration.py
@@ -1,0 +1,259 @@
+"""
+Purpose: Integration tests for Law of Demeter linter end-to-end
+
+Scope: Python code in -> violations out through complete LawOfDemeterRule pipeline
+
+Overview: End-to-end integration tests that exercise the full linter pipeline: parse Python
+    code, extract chains, classify each chain through the 9-filter pipeline, and produce
+    Violation objects. Uses fixture code samples from real-world repos to validate both
+    detection accuracy (true positives detected) and false-positive filtering (legitimate
+    patterns not flagged). Tests the LawOfDemeterRule class through its check() method
+    with mock contexts.
+
+Dependencies: pytest, src.linters.law_of_demeter.linter, unittest.mock, pathlib
+
+Exports: TestIntegrationTruePositives (5 tests), TestIntegrationFalsePositives (8 tests),
+    TestIntegrationEdgeCases (4 tests) - total 17 test cases
+
+Interfaces: Tests LawOfDemeterRule.check(context) -> list[Violation]
+
+Implementation: Creates mock BaseLintContext, invokes rule.check(), verifies violation
+    count and content
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+
+def _create_python_context(code: str, filename: str = "app.py") -> Mock:
+    """Create mock lint context for Python code."""
+    context = Mock()
+    context.file_content = code
+    context.file_path = Path(filename)
+    context.language = "python"
+    context.metadata = {}
+    return context
+
+
+class TestIntegrationTruePositives:
+    """Test that genuine LoD violations are detected end-to-end."""
+
+    def test_detects_deep_attribute_chain(self) -> None:
+        """Should detect order.customer.address.city."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def process_order(order):
+    name = order.customer.address.city
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        assert "law-of-demeter" in violations[0].rule_id
+
+    def test_detects_method_chain_violation(self) -> None:
+        """Should detect service.get_client().fetch_data().parse()."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def get_info(service):
+    data = service.get_client().fetch_data().parse()
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+
+    def test_detects_multiple_violations(self) -> None:
+        """Should detect multiple violations in same function."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def complex_handler(request):
+    user_city = request.user.profile.address.city
+    manager_name = request.department.manager.full_name
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        # request.user.profile.address.city is not safe-prefix (request. not in safe list)
+        # and request.department.manager.full_name similar
+        assert len(violations) >= 1
+
+    def test_reports_correct_line_number(self) -> None:
+        """Should report violation on the correct line."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    pass
+
+def g():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        assert violations[0].line == 6
+
+    def test_violation_has_suggestion(self) -> None:
+        """Should include a suggestion for fixing the violation."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        assert violations[0].suggestion is not None
+
+
+class TestIntegrationFalsePositives:
+    """Test that legitimate patterns are NOT flagged."""
+
+    def test_self_access_not_flagged(self) -> None:
+        """self.config.database.host should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+class MyClass:
+    def method(self):
+        return self.config.database.host
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_module_access_not_flagged(self) -> None:
+        """os.path.expanduser().strip() should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+import os
+def get_home():
+    return os.path.expanduser("~").strip()
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_string_chain_not_flagged(self) -> None:
+        """text.strip().lower().replace() should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def clean(text):
+    return text.strip().lower().replace("-", "_")
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_orm_chain_not_flagged(self) -> None:
+        """db.query().filter().order_by().limit() should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def get_active_users(db):
+    return db.query(User).filter(active=True).order_by("name").limit(10)
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_dunder_chain_not_flagged(self) -> None:
+        """obj.__class__.__name__.lower() should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def get_class_name(obj):
+    return obj.__class__.__name__.lower()
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_settings_access_not_flagged(self) -> None:
+        """settings.database.connection.host should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def configure(settings):
+    host = settings.database.connection.host
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_short_chain_not_flagged(self) -> None:
+        """Chains below min_depth should not be flagged."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def get_name(user):
+    return user.address.city
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) == 0
+
+    def test_test_file_not_flagged(self) -> None:
+        """Violations in test files should not be flagged by default."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def test_response(client):
+    assert client.get("/api").json()["data"].get("id") == 1
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code, "test_api.py"))
+        assert len(violations) == 0
+
+
+class TestIntegrationEdgeCases:
+    """Test edge cases in the full pipeline."""
+
+    def test_empty_file(self) -> None:
+        """Should handle empty files gracefully."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(""))
+        assert violations == []
+
+    def test_syntax_error_handled(self) -> None:
+        """Should handle syntax errors gracefully."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = "def f(:\n    pass"
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        # Should return syntax error violation or empty, not crash
+        assert isinstance(violations, list)
+
+    def test_disabled_returns_empty(self) -> None:
+        """Should return empty when disabled."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        context = _create_python_context(code)
+        context.metadata = {"law-of-demeter": {"enabled": False}}
+        violations = rule.check(context)
+        assert violations == []
+
+    def test_no_file_content_returns_empty(self) -> None:
+        """Should return empty when file_content is None."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        rule = LawOfDemeterRule()
+        context = Mock()
+        context.file_content = None
+        context.file_path = Path("app.py")
+        context.language = "python"
+        context.metadata = {}
+        violations = rule.check(context)
+        assert violations == []

--- a/tests/unit/linters/law_of_demeter/test_python_analyzer.py
+++ b/tests/unit/linters/law_of_demeter/test_python_analyzer.py
@@ -1,0 +1,151 @@
+"""
+Purpose: Test PythonDemeterAnalyzer for chain extraction and import tracking
+
+Scope: AST-based chain extraction, import extraction, and chain deduplication
+
+Overview: Validates the PythonDemeterAnalyzer class that walks Python AST trees to find
+    attribute/method chains meeting minimum depth, extracts import information for the
+    module-access filter, and deduplicates chains (keeping longest per line). Tests cover
+    extract_chains() behavior with various code patterns and extract_imports() for both
+    'import x' and 'from x import y' styles.
+
+Dependencies: pytest, ast, src.linters.law_of_demeter.python_analyzer
+
+Exports: TestExtractChains (6 tests), TestExtractImports (5 tests) - total 11 test cases
+
+Interfaces: Tests PythonDemeterAnalyzer.extract_chains() and extract_imports()
+
+Implementation: Parses Python code strings via ast.parse(), calls analyzer methods,
+    verifies chain extraction results and import tracking
+"""
+
+import ast
+
+
+class TestExtractChains:
+    """Test chain extraction from Python AST."""
+
+    def test_finds_depth_3_chain(self) -> None:
+        """Should find chains of depth >= 3."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        code = "x = a.b.c.d"
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert len(chains) >= 1
+
+    def test_skips_short_chains(self) -> None:
+        """Should skip chains shorter than min_depth."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        code = "x = a.b"
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert len(chains) == 0
+
+    def test_deduplicates_by_line(self) -> None:
+        """Should keep only longest chain per line."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        # a.b.c.d contains sub-chain a.b.c - should only report longest
+        code = "x = a.b.c.d"
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert len(chains) == 1
+
+    def test_finds_chains_in_multiple_functions(self) -> None:
+        """Should find chains across different functions."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        code = """
+def f1():
+    a.b.c.d
+
+def f2():
+    x.y.z.w
+"""
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert len(chains) == 2
+
+    def test_finds_chains_in_method_calls(self) -> None:
+        """Should find chains involving method calls."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        code = "x = a.b().c.d"
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert len(chains) >= 1
+
+    def test_empty_code_returns_no_chains(self) -> None:
+        """Should return empty list for empty code."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        tree = ast.parse("")
+        analyzer = PythonDemeterAnalyzer()
+        chains = analyzer.extract_chains(tree, min_depth=3)
+        assert chains == []
+
+
+class TestExtractImports:
+    """Test import extraction from Python AST."""
+
+    def test_extracts_import_module(self) -> None:
+        """Should track 'import os' as module name."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        tree = ast.parse("import os")
+        analyzer = PythonDemeterAnalyzer()
+        imports = analyzer.extract_imports(tree)
+        assert "os" in imports.module_names
+
+    def test_extracts_aliased_import(self) -> None:
+        """Should track 'import numpy as np' using alias."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        tree = ast.parse("import numpy as np")
+        analyzer = PythonDemeterAnalyzer()
+        imports = analyzer.extract_imports(tree)
+        assert "np" in imports.module_names
+
+    def test_extracts_from_import(self) -> None:
+        """Should track 'from pathlib import Path' mapping."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        tree = ast.parse("from pathlib import Path")
+        analyzer = PythonDemeterAnalyzer()
+        imports = analyzer.extract_imports(tree)
+        assert "Path" in imports.from_imports
+        assert imports.from_imports["Path"] == "pathlib"
+
+    def test_extracts_aliased_from_import(self) -> None:
+        """Should track 'from datetime import datetime as dt' using alias."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        tree = ast.parse("from datetime import datetime as dt")
+        analyzer = PythonDemeterAnalyzer()
+        imports = analyzer.extract_imports(tree)
+        assert "dt" in imports.from_imports
+
+    def test_multiple_imports(self) -> None:
+        """Should handle multiple import statements."""
+        from src.linters.law_of_demeter.python_analyzer import PythonDemeterAnalyzer
+
+        code = """
+import os
+import sys
+from pathlib import Path
+from typing import Any
+"""
+        tree = ast.parse(code)
+        analyzer = PythonDemeterAnalyzer()
+        imports = analyzer.extract_imports(tree)
+        assert "os" in imports.module_names
+        assert "sys" in imports.module_names
+        assert "Path" in imports.from_imports
+        assert "Any" in imports.from_imports

--- a/tests/unit/linters/law_of_demeter/test_violation_messages.py
+++ b/tests/unit/linters/law_of_demeter/test_violation_messages.py
@@ -1,0 +1,107 @@
+"""
+Purpose: Test violation message formatting for Law of Demeter linter
+
+Scope: Violation message content, rule_id format, severity, and suggestion text
+
+Overview: Validates that LoD violations are reported with correct rule_id format,
+    meaningful error messages including chain depth and chain representation,
+    proper severity (ERROR), file path and line number, and helpful suggestions
+    for refactoring.
+
+Dependencies: pytest, src.linters.law_of_demeter.linter, unittest.mock, pathlib
+
+Exports: TestViolationMessages (5 tests)
+
+Interfaces: Tests violation object fields produced by LawOfDemeterRule.check()
+
+Implementation: Creates violations via rule.check() with known code samples,
+    inspects Violation dataclass fields
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+from src.core.types import Severity
+
+
+def _create_python_context(code: str, filename: str = "app.py") -> Mock:
+    """Create mock lint context for Python code."""
+    context = Mock()
+    context.file_content = code
+    context.file_path = Path(filename)
+    context.language = "python"
+    context.metadata = {}
+    return context
+
+
+class TestViolationMessages:
+    """Test violation message content and format."""
+
+    def test_rule_id_format(self) -> None:
+        """Should use 'law-of-demeter.chain-depth' rule_id."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        assert "law-of-demeter" in violations[0].rule_id
+
+    def test_severity_is_error(self) -> None:
+        """Should report ERROR severity."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        assert violations[0].severity == Severity.ERROR
+
+    def test_message_includes_chain_depth(self) -> None:
+        """Should mention chain depth in the message."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        # Message should reference depth or chain
+        msg = violations[0].message.lower()
+        assert "chain" in msg or "depth" in msg or "demeter" in msg
+
+    def test_file_path_set(self) -> None:
+        """Should include file path in violation."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code, "src/handler.py"))
+        assert len(violations) >= 1
+        assert "handler.py" in violations[0].file_path
+
+    def test_suggestion_provides_guidance(self) -> None:
+        """Should provide actionable refactoring suggestion."""
+        from src.linters.law_of_demeter.linter import LawOfDemeterRule
+
+        code = """
+def f():
+    x = a.b.c.d
+"""
+        rule = LawOfDemeterRule()
+        violations = rule.check(_create_python_context(code))
+        assert len(violations) >= 1
+        suggestion = violations[0].suggestion
+        assert suggestion is not None
+        assert len(suggestion) > 10  # Should be meaningful text


### PR DESCRIPTION
## Summary
- Add 112 RED tests for the Law of Demeter linter across 16 test files
- Create test fixture corpus with true-positive and false-positive Python/TypeScript code samples derived from 23 real-world repos
- Tests cover: config loading, chain extraction, Python analysis, all 9 classifier filters (safe-prefix, module-access, string-chain, fluent-chain, ast-traversal, dunder-access, subscript-access, safe-terminal, test-file), integration, violation messages, and ignore directives
- Tests import from `src.linters.law_of_demeter` which doesn't exist yet — all tests are RED (skipped via conftest.py `pytest_ignore_collect` hook until implementation exists)

## Test plan
- [x] All 2266 existing tests pass (0 failures)
- [x] `just lint-full` passes all 17 quality checks
- [x] LoD test files are properly skipped during collection (no import errors)
- [x] Tests will auto-enable when `src/linters/law_of_demeter/` module is created in PR 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)