### PR TITLE
fix: add Law of Demeter linter to README table

### DIFF
--- a/.ai/index.yaml
+++ b/.ai/index.yaml
@@ -10,7 +10,7 @@ project:
   type: cli
   purpose: The AI Linter - Lint and governance for AI-generated code across multiple languages
   status: in-development
-  version: "0.19.0"
+  version: "0.19.1"
 
 core_documents:
   - ai-context.md       # Development context and patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-05-11
+
+### Fixed
+
+- **README** - Add Law of Demeter linter to PyPI linter table
+
 ## [0.19.0] - 2026-05-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI](https://img.shields.io/badge/pypi-v0.19.0-orange)](https://pypi.org/project/thailint/)
+[![PyPI](https://img.shields.io/badge/pypi-v0.19.1-orange)](https://pypi.org/project/thailint/)
 [![Tests](https://img.shields.io/badge/tests-2122%2F2122%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
 [![Documentation](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/)
@@ -57,6 +57,7 @@ That's it. See violations, fix them, ship better code.
 | **Improper Logging** | Print statements and conditional verbose patterns | `thailint improper-logging src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/improper-logging-linter/) |
 | **Stringly Typed** | Strings that should be enums | `thailint stringly-typed src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/stringly-typed-linter/) |
 | **LBYL** | Look Before You Leap anti-patterns | `thailint lbyl src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/lbyl-linter/) |
+| **Law of Demeter** | Deep object chain access (reaching through objects) | `thailint law-of-demeter src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/law-of-demeter-linter/) |
 | **Version Freshness** | EOL/outdated runtime versions in infra files | `thailint version-freshness .` | [Guide](https://thai-lint.readthedocs.io/en/latest/version-freshness-linter/) |
 | **Unwrap Abuse** | `.unwrap()`/`.expect()` that panic at runtime (Rust) | `thailint unwrap-abuse src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/unwrap-abuse-linter/) |
 | **Clone Abuse** | `.clone()` abuse: loops, chains, unnecessary (Rust) | `thailint clone-abuse src/` | [Guide](https://thai-lint.readthedocs.io/en/latest/clone-abuse-linter/) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.19.0"
+version = "0.19.1"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add Law of Demeter linter to README's linter feature table (displayed on PyPI)
- Bump version to 0.19.1

## Test plan
- [ ] Verify PyPI page shows the LoD linter after republish

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>