### PR TITLE
fix: detect Markdown/bash/css extensions and correct file-header config docs (#212)

### DIFF
--- a/docs/file-header-linter.md
+++ b/docs/file-header-linter.md
@@ -212,16 +212,15 @@ Add to `.thailint.yaml`:
 file-header:
   enabled: true
 
-  # Mandatory fields (must have non-empty values)
-  mandatory_fields:
+  # Required fields (must have non-empty values).
+  # A list applies the same fields to every language.
+  required_fields:
     - Purpose
     - Scope
     - Overview
 
-  # Recommended fields (warned if missing)
-  recommended_fields:
-    - Dependencies
-    - Exports
+  # Enable atemporal language detection (dates, "currently", "now", etc.)
+  enforce_atemporal: true
 
   # Files to ignore
   ignore:
@@ -236,10 +235,9 @@ file-header:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `enabled` | boolean | `true` | Enable/disable file header linter |
-| `mandatory_fields` | array | `[Purpose, Scope, Overview]` | Fields that must be present |
-| `recommended_fields` | array | `[Dependencies, Exports]` | Fields that generate warnings if missing |
-| `check_atemporal` | boolean | `true` | Enable atemporal language detection |
-| `ignore` | array | `[]` | Glob patterns for files to skip |
+| `required_fields` | array or map | language-specific defaults | Fields that must be present. A list applies to all languages; a map keyed by language (`python`, `typescript`, `bash`, `markdown`, `css`) sets fields per language |
+| `enforce_atemporal` | boolean | `true` | Enable atemporal language detection |
+| `ignore` | array | `["test/**", "**/migrations/**", "**/__init__.py"]` | Glob patterns for files to skip |
 
 ### Language-Specific Configuration
 
@@ -247,29 +245,26 @@ file-header:
 file-header:
   enabled: true
 
-  # Language-specific mandatory fields
-  languages:
+  # Language-specific required fields: a map keyed by language, each value a list of fields
+  required_fields:
     python:
-      mandatory_fields:
-        - Purpose
-        - Scope
-        - Overview
-        - Dependencies
-        - Exports
+      - Purpose
+      - Scope
+      - Overview
+      - Dependencies
+      - Exports
 
     typescript:
-      mandatory_fields:
-        - Purpose
-        - Scope
-        - Overview
-        - Dependencies
-        - Exports
+      - Purpose
+      - Scope
+      - Overview
+      - Dependencies
+      - Exports
 
     markdown:
-      mandatory_fields:
-        - purpose      # YAML frontmatter uses lowercase
-        - scope
-        - overview
+      - purpose      # YAML frontmatter uses lowercase
+      - scope
+      - overview
 ```
 
 ### JSON Configuration
@@ -278,9 +273,8 @@ file-header:
 {
   "file-header": {
     "enabled": true,
-    "mandatory_fields": ["Purpose", "Scope", "Overview"],
-    "recommended_fields": ["Dependencies", "Exports"],
-    "check_atemporal": true,
+    "required_fields": ["Purpose", "Scope", "Overview"],
+    "enforce_atemporal": true,
     "ignore": [
       "**/__init__.py",
       "**/migrations/**"

--- a/examples/file_header_usage.py
+++ b/examples/file_header_usage.py
@@ -30,10 +30,10 @@ def example_high_level_api():
     print("=== Example 1: High-level API ===\n")
 
     # Initialize linter with config file
-    linter = Linter(config_file='.thailint.yaml')
+    linter = Linter(config_file=".thailint.yaml")
 
     # Lint directory with file-header rule
-    violations = linter.lint('src/', rules=['file-header'])
+    violations = linter.lint("src/", rules=["file-header"])
 
     # Process violations
     if violations:
@@ -52,7 +52,7 @@ def example_direct_file_header_lint():
     print("=== Example 2: Direct file_header_lint() ===\n")
 
     # Lint specific file with default config
-    violations = file_header_lint('src/cli.py')
+    violations = file_header_lint("src/cli.py")
 
     if violations:
         print(f"Found {len(violations)} violations in src/cli.py:\n")
@@ -66,19 +66,14 @@ def example_custom_configuration():
     """Example 3: Custom configuration without config file."""
     print("=== Example 3: Custom Configuration ===\n")
 
-    # Lint with custom mandatory fields
+    # Lint with custom required fields
     violations = file_header_lint(
-        'src/linters/',
-        config={
-            'mandatory_fields': ['Purpose', 'Scope', 'Overview'],
-            'recommended_fields': ['Dependencies', 'Exports'],
-            'check_atemporal': True
-        }
+        "src/linters/",
+        config={"required_fields": ["Purpose", "Scope", "Overview"], "enforce_atemporal": True},
     )
 
     print("Checking src/linters/ with custom config:")
-    print("  Mandatory fields: [Purpose, Scope, Overview]")
-    print("  Recommended fields: [Dependencies, Exports]")
+    print("  Required fields: [Purpose, Scope, Overview]")
     print(f"  Violations: {len(violations)}\n")
 
 
@@ -86,19 +81,24 @@ def example_strict_configuration():
     """Example 4: Strict configuration (all fields mandatory)."""
     print("=== Example 4: Strict Configuration ===\n")
 
-    # Strict mode - all fields mandatory
+    # Strict mode - all fields required
     violations = file_header_lint(
-        'src/config.py',
+        "src/config.py",
         config={
-            'mandatory_fields': [
-                'Purpose', 'Scope', 'Overview',
-                'Dependencies', 'Exports', 'Interfaces', 'Implementation'
+            "required_fields": [
+                "Purpose",
+                "Scope",
+                "Overview",
+                "Dependencies",
+                "Exports",
+                "Interfaces",
+                "Implementation",
             ],
-            'check_atemporal': True
-        }
+            "enforce_atemporal": True,
+        },
     )
 
-    print("Strict mode: All fields mandatory")
+    print("Strict mode: All fields required")
     if violations:
         print(f"  Found {len(violations)} violations (more strict)\n")
         for v in violations[:3]:  # Show first 3
@@ -112,9 +112,9 @@ def example_process_multiple_files():
     print("=== Example 5: Multiple Files ===\n")
 
     files_to_check = [
-        'src/cli.py',
-        'src/config.py',
-        'src/api.py',
+        "src/cli.py",
+        "src/config.py",
+        "src/api.py",
     ]
 
     all_violations = []
@@ -134,7 +134,7 @@ def example_with_error_handling():
 
     try:
         # Attempt to lint non-existent file
-        violations = file_header_lint('nonexistent.py')
+        violations = file_header_lint("nonexistent.py")
         print(f"Violations: {len(violations)}")
     except FileNotFoundError as e:
         print(f"File not found: {e}")
@@ -149,7 +149,7 @@ def example_check_header_format():
     print("=== Example 7: Header Format Check ===\n")
 
     # Create temporary file with incomplete header
-    test_file = Path('/tmp/test_header.py')
+    test_file = Path("/tmp/test_header.py")
     test_file.write_text('''"""
 Purpose: Test module for demonstration
 """
@@ -177,7 +177,7 @@ def example_atemporal_language_detection():
     print("=== Example 8: Atemporal Language Detection ===\n")
 
     # Create test file with temporal language
-    test_file = Path('/tmp/test_atemporal.py')
+    test_file = Path("/tmp/test_atemporal.py")
     test_file.write_text('''"""
 Purpose: Test module for temporal language detection
 
@@ -215,8 +215,8 @@ def example_typescript_header_check():
     print("=== Example 9: TypeScript Header Check ===\n")
 
     # Create test TypeScript file
-    test_file = Path('/tmp/test_header.ts')
-    test_file.write_text('''/**
+    test_file = Path("/tmp/test_header.ts")
+    test_file.write_text("""/**
  * Purpose: User authentication component
  *
  * Scope: Authentication UI, login form
@@ -233,7 +233,7 @@ import React from 'react';
 export const LoginForm = () => {
     return <form>Login</form>;
 };
-''')
+""")
 
     violations = file_header_lint(str(test_file))
 
@@ -253,8 +253,8 @@ def example_bash_header_check():
     print("=== Example 10: Bash Script Header Check ===\n")
 
     # Create test Bash script
-    test_file = Path('/tmp/test_script.sh')
-    test_file.write_text('''#!/bin/bash
+    test_file = Path("/tmp/test_script.sh")
+    test_file.write_text("""#!/bin/bash
 # Purpose: Database backup script
 #
 # Scope: Database operations, scheduled tasks
@@ -269,7 +269,7 @@ def example_bash_header_check():
 set -euo pipefail
 
 pg_dump mydb > backup.sql
-''')
+""")
 
     violations = file_header_lint(str(test_file))
 

--- a/src/orchestrator/language_detector.py
+++ b/src/orchestrator/language_detector.py
@@ -6,18 +6,19 @@ Scope: Language identification for routing files to appropriate analyzers and ru
 Overview: Detects programming language from files using multiple strategies including file
     extension mapping, shebang line parsing for scripts, and content analysis. Provides simple
     extension-to-language mapping for common file types (.py -> python, .js -> javascript,
-    .ts -> typescript, .java -> java, .go -> go). Falls back to shebang parsing for extensionless
-    scripts by reading first line and checking for language indicators. Returns 'unknown' for
-    unrecognized files, allowing the orchestrator to skip or apply language-agnostic rules.
-    Enables the multi-language architecture by accurately identifying file types for proper
-    rule routing and analyzer selection.
+    .ts -> typescript, .java -> java, .go -> go, .rs -> rust, .md -> markdown, .sh/.bash -> bash,
+    .css/.scss -> css). Falls back to shebang parsing for extensionless scripts by reading first
+    line and checking for language indicators. Returns 'unknown' for unrecognized files, allowing
+    the orchestrator to skip or apply language-agnostic rules. Enables the multi-language
+    architecture by accurately identifying file types for proper rule routing and analyzer
+    selection.
 
 Dependencies: pathlib for file path handling and content reading
 
 Exports: detect_language(file_path: Path) -> str function, EXTENSION_MAP constant
 
 Interfaces: detect_language(file_path: Path) -> str returns language identifier string
-    (python, javascript, typescript, java, go, rust, unknown)
+    (python, javascript, typescript, java, go, rust, markdown, bash, css, unknown)
 
 Implementation: Dictionary-based extension lookup for O(1) detection, first-line shebang
     parsing with substring matching, lazy file reading only when extension unknown
@@ -36,6 +37,11 @@ EXTENSION_MAP = {
     ".java": "java",
     ".go": "go",
     ".rs": "rust",
+    ".md": "markdown",
+    ".sh": "bash",
+    ".bash": "bash",
+    ".css": "css",
+    ".scss": "css",
 }
 
 

--- a/tests/integration/test_file_header_markdown_e2e.py
+++ b/tests/integration/test_file_header_markdown_e2e.py
@@ -1,0 +1,39 @@
+"""
+Purpose: End-to-end test that file-header validates Markdown files through the orchestrator
+
+Scope: Regression coverage for the language-detection gap that silently skipped .md files
+
+Overview: Exercises the full linting pipeline via the public Linter API to confirm that a
+    Markdown file lacking YAML frontmatter is reported by the file-header linter. The original
+    defect was that the orchestrator's language detector returned "unknown" for .md files, so
+    FileHeaderRule short-circuited before reaching the registered MarkdownHeaderParser. Unit
+    tests injected the language directly and therefore never caught the gap; this test routes a
+    real file through detect_language so the regression cannot recur.
+
+Dependencies: pytest, tmp_path fixture, src.api.Linter
+
+Exports: TestMarkdownFileHeaderEndToEnd test class
+
+Interfaces: Tests Linter.lint(path) -> list[Violation] for .md files
+
+Implementation: Creates a frontmatter-less Markdown file in a temp project and asserts the
+    file-header rule emits at least one violation for it
+"""
+
+from pathlib import Path
+
+from src.api import Linter
+
+
+class TestMarkdownFileHeaderEndToEnd:
+    """Validate Markdown file-header detection through the orchestrator."""
+
+    def test_markdown_without_frontmatter_is_flagged(self, tmp_path: Path) -> None:
+        """A .md file with no frontmatter should be reported by file-header."""
+        md_file = tmp_path / "unheadered.md"
+        md_file.write_text("# Just a heading, no YAML frontmatter, no fields at all.\n")
+
+        linter = Linter(project_root=str(tmp_path))
+        violations = linter.lint(str(md_file), rules=["file-header.validation"])
+
+        assert len(violations) >= 1, "file-header should flag a frontmatter-less .md file"

--- a/tests/unit/orchestrator/test_language_detection.py
+++ b/tests/unit/orchestrator/test_language_detection.py
@@ -4,22 +4,45 @@ Purpose: Test suite for programming language detection from files
 Scope: Validation of language detection by extension, shebang, and content analysis
 
 Overview: Validates the language detection system that determines programming language from
-    file extensions, shebang lines, and file content. Tests verify detection from common
-    extensions (.py, .js, .ts, .java, .go), shebang parsing for scripts without extensions,
-    and fallback to 'unknown' for unrecognized files. Ensures the orchestrator can correctly
-    route files to language-specific analyzers and rules by accurately identifying the
-    programming language of each file being linted.
+    file extensions. Tests verify detection of the file-header supported extensions that the
+    orchestrator must route to language-specific parsers (.md -> markdown, .sh/.bash -> bash,
+    .css/.scss -> css), including case-insensitive matching. Ensures the orchestrator can
+    correctly route these files to language-specific analyzers and rules by accurately
+    identifying the programming language of each file being linted.
 
-Dependencies: pytest for testing framework, pathlib for file creation, tmp_path fixture
+Dependencies: pytest for testing framework, pathlib for Path objects
 
 Exports: TestLanguageDetection test class
 
 Interfaces: Tests detect_language(file_path: Path) -> str function with various file types
 
-Implementation: 7 tests covering extension-based detection for multiple languages,
-    shebang parsing for extensionless scripts, unknown file handling
+Implementation: Extension-based detection tests for markdown, bash, and css file types,
+    plus case-insensitive matching
 """
+
+from pathlib import Path
+
+from src.orchestrator.language_detector import detect_language
 
 
 class TestLanguageDetection:
     """Test language detection from files."""
+
+    def test_detect_markdown_extension(self) -> None:
+        """Test .md files detected as markdown."""
+        assert detect_language(Path("README.md")) == "markdown"
+        assert detect_language(Path("docs/guide.md")) == "markdown"
+
+    def test_detect_markdown_case_insensitive(self) -> None:
+        """Test .MD extension detected as markdown (case insensitive)."""
+        assert detect_language(Path("README.MD")) == "markdown"
+
+    def test_detect_bash_extension(self) -> None:
+        """Test .sh and .bash files detected as bash."""
+        assert detect_language(Path("deploy.sh")) == "bash"
+        assert detect_language(Path("setup.bash")) == "bash"
+
+    def test_detect_css_extension(self) -> None:
+        """Test .css and .scss files detected as css."""
+        assert detect_language(Path("styles.css")) == "css"
+        assert detect_language(Path("theme.scss")) == "css"


### PR DESCRIPTION
## Summary

Fixes #212. Two friction points reported while integrating thai-lint into a docs-heavy repo:

1. **`file-header` silently no-op'd on `.md` files** (and `.sh`/`.bash`/`.css`/`.scss`). Root cause: `orchestrator/language_detector.py::EXTENSION_MAP` had no entry for these, so `detect_language()` returned `"unknown"` and `FileHeaderRule._check_language_header` short-circuited at `self._parsers.get(context.language)` — even though the markdown/bash/css parsers were already registered. Added the missing extensions.
2. **Published config docs didn't match the code schema.** Following the docs as-written configured nothing. Corrected the docs (and a runnable example) to the keys the code actually reads. The code schema is intentionally **unchanged** so existing working configs keep working.

## Changes

- `src/orchestrator/language_detector.py` — add `.md`→markdown, `.sh`/`.bash`→bash, `.css`/`.scss`→css to `EXTENSION_MAP`. Other linters (dry/srp/nesting/magic_numbers) use positive language matching, so they still skip these files; only file-header newly processes them.
- `docs/file-header-linter.md` + `examples/file_header_usage.py` — `mandatory_fields`→`required_fields`, `check_atemporal`→`enforce_atemporal`, fix the `languages.<lang>.mandatory_fields` nesting to `required_fields.<lang>`, and drop the never-implemented `recommended_fields`.

## Tests (TDD)

- `tests/unit/orchestrator/test_language_detection.py` — extension detection for the 5 new extensions, incl. case-insensitive. Written failing first (`'unknown' != 'markdown'`), then passing.
- `tests/integration/test_file_header_markdown_e2e.py` — routes a frontmatter-less `.md` through the public `Linter` API (the real orchestrator path the existing unit tests bypassed by injecting `language="markdown"` directly).

## Verification

- `just lint-full` → exit 0, all 17 checks pass (Pylint 10.00, Xenon A-grade, MyPy clean)
- `just test` → exit 0, 2416 passed, 19 skipped

## Not included (separate / optional)

- **Pre-existing, unrelated bug:** `examples/file_header_usage.py` imports `from src.linters.file_header import lint`, but that package exports only `FileHeaderRule` (no `lint` function, unlike file_placement/nesting/srp), so the example `ImportError`s. Left for a separate change.
- Issue's "bonus" items: `config show` doc note, file-placement wrapper-key docs, and a `--verbose` skipped-files listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)