### PR TITLE
fix: make DRY overlap dedup linear instead of O(v²) per file (#213)

### DIFF
--- a/src/linters/dry/deduplicator.py
+++ b/src/linters/dry/deduplicator.py
@@ -64,26 +64,19 @@ class ViolationDeduplicator:
         Returns:
             Non-overlapping blocks
         """
+        # Sweep-line: blocks are sorted by start line and kept blocks are non-overlapping, so
+        # their end lines strictly ascend and the most recently kept block has the largest end.
+        # A block therefore overlaps some kept block iff it overlaps the last kept one, so a
+        # single comparison against kept_blocks[-1] replaces the O(v^2) scan over all kept
+        # blocks with an O(v) sweep (issue #213).
         sorted_blocks = sorted(file_blocks, key=lambda b: b.start_line)
         kept_blocks: list[CodeBlock] = []
 
         for block in sorted_blocks:
-            if not self._overlaps_any_kept(block, kept_blocks):
+            if not kept_blocks or not self._blocks_overlap(block, kept_blocks[-1]):
                 kept_blocks.append(block)
 
         return kept_blocks
-
-    def _overlaps_any_kept(self, block: CodeBlock, kept_blocks: list[CodeBlock]) -> bool:
-        """Check if block overlaps with any kept blocks.
-
-        Args:
-            block: Block to check
-            kept_blocks: Previously kept blocks
-
-        Returns:
-            True if block overlaps with any kept block
-        """
-        return any(self._blocks_overlap(block, kept) for kept in kept_blocks)
 
     def _blocks_overlap(self, block1: CodeBlock, block2: CodeBlock) -> bool:
         """Check if two blocks overlap (share any lines).

--- a/src/linters/dry/violation_filter.py
+++ b/src/linters/dry/violation_filter.py
@@ -38,23 +38,16 @@ class ViolationFilter:
         Returns:
             Filtered list with overlaps removed
         """
+        # Sweep-line: with ascending line order, kept violations also ascend, so the most
+        # recently kept one has the largest line. The overlap test depends only on the current
+        # violation's line count, so a violation overlaps some kept violation iff it overlaps
+        # the last kept one. Comparing against only kept[-1] is equivalent to scanning all kept
+        # and turns this from O(v^2) into O(v) (issue #213).
         kept: list[Violation] = []
         for violation in sorted_violations:
-            if not self._overlaps_any(violation, kept):
+            if not kept or not self._overlaps(violation, kept[-1]):
                 kept.append(violation)
         return kept
-
-    def _overlaps_any(self, violation: Violation, kept_violations: list[Violation]) -> bool:
-        """Check if violation overlaps with any kept violations.
-
-        Args:
-            violation: Violation to check
-            kept_violations: Previously kept violations
-
-        Returns:
-            True if violation overlaps with any kept violation
-        """
-        return any(self._overlaps(violation, kept) for kept in kept_violations)
 
     def _overlaps(self, v1: Violation, v2: Violation) -> bool:
         """Check if two violations overlap.

--- a/tests/unit/linters/dry/test_overlap_dedup_performance.py
+++ b/tests/unit/linters/dry/test_overlap_dedup_performance.py
@@ -1,0 +1,156 @@
+"""
+Purpose: Regression tests for DRY overlap-deduplication scaling and behavior preservation
+
+Scope: ViolationFilter.filter_overlapping and ViolationDeduplicator block/violation dedup
+
+Overview: Guards against the O(v^2) blow-up reported in issue #213, where the per-file overlap
+    dedup compared each block/violation against every previously kept item, hanging for over an
+    hour on files with thousands of internal duplicates. Verifies the dedup now scales linearly by
+    counting how many pairwise overlap comparisons run on a pathological single-file input (each
+    item compared against only the last kept item). Also pins behavior with independent brute-force
+    reference implementations so the linear rewrite produces identical output to the original
+    all-pairs logic across randomized inputs.
+
+Dependencies: pytest, unittest.mock, pathlib.Path, src.core.types.Violation,
+    src.linters.dry.cache.CodeBlock, ViolationFilter, ViolationDeduplicator
+
+Exports: TestOverlapDedupScaling, TestOverlapDedupEquivalence test classes
+
+Interfaces: Tests filter_overlapping(violations) and deduplicate_blocks/deduplicate_violations
+
+Implementation: Comparison-count instrumentation via mock wrappers for scaling assertions;
+    inline brute-force references for equivalence assertions on randomized inputs
+"""
+
+import random
+from pathlib import Path
+from unittest.mock import patch
+
+from src.core.types import Violation
+from src.linters.dry.cache import CodeBlock
+from src.linters.dry.deduplicator import ViolationDeduplicator
+from src.linters.dry.violation_filter import ViolationFilter
+
+# Size of the pathological single-file input. Large enough that the original
+# O(v^2) all-pairs scan vastly exceeds a linear comparison budget.
+PATHOLOGICAL_N = 500
+
+
+def make_violation(line: int, line_count: int = 4) -> Violation:
+    """Build a DRY-style violation whose message encodes the duplicate line count."""
+    return Violation(
+        rule_id="dry.duplicate-code",
+        file_path="repetitive.py",
+        line=line,
+        column=1,
+        message=f"Duplicate code ({line_count} lines, 2 occurrences) detected",
+    )
+
+
+def make_block(start_line: int, line_count: int = 4) -> CodeBlock:
+    """Build a CodeBlock spanning line_count lines from start_line."""
+    return CodeBlock(
+        file_path=Path("repetitive.py"),
+        start_line=start_line,
+        end_line=start_line + line_count - 1,
+        snippet="x = 1\ny = 2\nz = 3\nw = 4",
+        hash_value=42,
+    )
+
+
+def _bruteforce_filter_violations(violations: list[Violation]) -> list[Violation]:
+    """Independent reference for the original all-pairs violation overlap filter."""
+
+    def line_count(message: str) -> int:
+        try:
+            start = message.index("(") + 1
+            end = message.index(" lines")
+            return int(message[start:end])
+        except (ValueError, IndexError):
+            return 5
+
+    ordered = sorted(violations, key=lambda v: v.line or 0)
+    kept: list[Violation] = []
+    for v in ordered:
+        if not any((v.line or 0) < (k.line or 0) + line_count(v.message) for k in kept):
+            kept.append(v)
+    return kept
+
+
+def _bruteforce_dedup_blocks(blocks: list[CodeBlock]) -> list[CodeBlock]:
+    """Independent reference for the original all-pairs block overlap dedup (single file)."""
+    ordered = sorted(blocks, key=lambda b: b.start_line)
+    kept: list[CodeBlock] = []
+    for b in ordered:
+        if not any(b.start_line <= k.end_line and k.start_line <= b.end_line for k in kept):
+            kept.append(b)
+    return kept
+
+
+class TestOverlapDedupScaling:
+    """Pairwise overlap comparisons must scale linearly, not quadratically (issue #213)."""
+
+    def test_violation_filter_runs_linear_comparison_count(self) -> None:
+        """filter_overlapping must compare each violation against O(1) kept items, not all."""
+        # Consecutive overlapping windows: the report's pathological repetitive-file shape.
+        violations = [make_violation(line) for line in range(1, PATHOLOGICAL_N + 1)]
+        vf = ViolationFilter()
+        original = vf._overlaps
+        calls = 0
+
+        def counting(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        with patch.object(vf, "_overlaps", side_effect=counting):
+            kept = vf.filter_overlapping(violations)
+
+        assert kept == _bruteforce_filter_violations(violations)
+        assert calls <= 4 * PATHOLOGICAL_N, f"expected linear comparisons, got {calls}"
+
+    def test_block_dedup_runs_linear_comparison_count(self) -> None:
+        """deduplicate_blocks must compare each block against O(1) kept blocks, not all."""
+        blocks = [make_block(line) for line in range(1, PATHOLOGICAL_N + 1)]
+        dedup = ViolationDeduplicator()
+        original = dedup._blocks_overlap
+        calls = 0
+
+        def counting(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+
+        with patch.object(dedup, "_blocks_overlap", side_effect=counting):
+            kept = dedup.deduplicate_blocks(blocks)
+
+        assert sorted(b.start_line for b in kept) == sorted(
+            b.start_line for b in _bruteforce_dedup_blocks(blocks)
+        )
+        assert calls <= 4 * PATHOLOGICAL_N, f"expected linear comparisons, got {calls}"
+
+
+class TestOverlapDedupEquivalence:
+    """Linear rewrite must produce identical output to the original all-pairs logic."""
+
+    def test_violation_filter_matches_bruteforce_on_random_inputs(self) -> None:
+        """filter_overlapping output equals the brute-force reference across random inputs."""
+        rng = random.Random(1234)
+        for _ in range(50):
+            lines = rng.sample(range(1, 300), rng.randint(1, 60))
+            violations = [make_violation(line, rng.randint(3, 8)) for line in lines]
+            expected = _bruteforce_filter_violations(violations)
+            actual = ViolationFilter().filter_overlapping(
+                sorted(violations, key=lambda v: v.line or 0)
+            )
+            assert [v.line for v in actual] == [v.line for v in expected]
+
+    def test_block_dedup_matches_bruteforce_on_random_inputs(self) -> None:
+        """deduplicate_blocks output equals the brute-force reference across random inputs."""
+        rng = random.Random(5678)
+        for _ in range(50):
+            starts = rng.sample(range(1, 300), rng.randint(1, 60))
+            blocks = [make_block(start, rng.randint(3, 8)) for start in starts]
+            expected = _bruteforce_dedup_blocks(blocks)
+            actual = ViolationDeduplicator().deduplicate_blocks(blocks)
+            assert sorted(b.start_line for b in actual) == sorted(b.start_line for b in expected)


### PR DESCRIPTION
## Summary

Fixes #213. The DRY linter's per-file **overlap dedup** scaled quadratically in the number of duplicate blocks per file. On a ~2,300-file repo with heavily repetitive files, the hashing phase finished in ~5 min but this post-processing phase then pegged a core at 99% for **90+ minutes with no output**.

Both hot loops compared each item against **all** previously kept items:
- `violation_filter.py` — `filter_overlapping` → `_overlaps_any` → `any(... for kept in kept)`
- `deduplicator.py` — `_remove_overlaps_from_file` → `_overlaps_any_kept` → `any(...)`

That's O(v²) per file; for files with thousands of internal duplicates, v² reaches the millions–billions.

## Fix

Replace the all-pairs scan with an **O(v) sweep** that compares each item against only the **last kept** item.

This is provably equivalent (not an approximation), so output is unchanged:
- Inputs are sorted (ascending line / start line) and kept items are non-overlapping, so the most recently kept item always has the maximal coordinate.
- Both overlap predicates are monotonic in that coordinate — the violation predicate depends only on the *current* item's line count (constant across the inner loop), and kept blocks have strictly ascending end lines.
- Therefore "overlaps any kept" ⟺ "overlaps the last kept".

As a side effect this also takes the `_extract_line_count` string-parse (report's secondary concern) from O(v²) to O(v) calls.

## Behavior preservation + tests

- **All 102 existing DRY tests pass unchanged** — pure performance rewrite.
- New `tests/unit/linters/dry/test_overlap_dedup_performance.py`:
  - **Scaling**: instruments pairwise-comparison count on a pathological single-file input. Was **31,375** comparisons for v=500 (O(v²)); now **< 2,000** (linear). Written failing first, then passing.
  - **Equivalence**: asserts the sweep matches an independent brute-force reference of the original all-pairs logic across 50 randomized inputs (for both violations and blocks).

## Verification

- `just lint-full` → exit 0, all checks pass (Pylint 10.00, Xenon A-grade, MyPy clean)
- `just test` → exit 0, 2420 passed, 19 skipped

## Not included (report's lower-impact follow-ups)

- Carrying `line_count`/start/end as numeric fields on the violation — now negligible since the string parse is no longer in a quadratic loop.
- Applying ignore-pattern filtering before generation rather than after.

Happy to do either as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)