### PR TITLE
chore: bump version to 0.19.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI](https://img.shields.io/badge/pypi-v0.19.2-orange)](https://pypi.org/project/thailint/)
+[![PyPI](https://img.shields.io/badge/pypi-v0.19.3-orange)](https://pypi.org/project/thailint/)
 [![Tests](https://img.shields.io/badge/tests-2435%2F2435%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
 [![Documentation](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.19.2"
+version = "0.19.3"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary

Bumps the version to **0.19.3** (patch).

- `pyproject.toml`: 0.19.2 → 0.19.3
- README PyPI badge updated to v0.19.3

`poetry lock` produced no changes (the lock has no root-package self-entry), so it's omitted.

## Covers

- #213 — DRY linter O(v²) overlap-dedup fixed (now linear)
- #212 — file-header Markdown/bash/css detection + config-docs fix (shipped in 0.19.2)

## Note on releasing

The `Publish` GitHub Actions workflow bumps the version itself. To release **exactly 0.19.3**, publish from the version already set here (e.g. `just publish --skip-checks` with 0.19.3 in pyproject, or run the workflow knowing it would bump to 0.19.4 from this base). Merging this PR keeps `main` reflecting the intended released version regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)