### PR TITLE
chore: Publish v0.19.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI](https://img.shields.io/badge/pypi-v0.19.3-orange)](https://pypi.org/project/thailint/)
-[![Tests](https://img.shields.io/badge/tests-2435%2F2435%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
+[![PyPI](https://img.shields.io/badge/pypi-v0.19.4-orange)](https://pypi.org/project/thailint/)
+[![Tests](https://img.shields.io/badge/tests-2439%2F2439%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
 [![Documentation](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.19.3"
+version = "0.19.4"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.19.4
- Updated poetry.lock
- Updated README badges (version, tests, coverage)

Captures the working-tree changes from the Publish workflow run. The release already succeeded; the workflow could not open this PR itself because GitHub Actions is blocked from creating PRs, so it's opened manually.

## Published
- PyPI: https://pypi.org/project/thailint/0.19.4/
- Docker Hub: tags `0.19.4`, `latest`

Includes the DRY O(v²) dedup fix (#213) and the file-header Markdown detection + config-docs fix (#212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)