### PR TITLE
fix: add file_header.lint() convenience function

### DIFF
--- a/src/linters/file_header/__init__.py
+++ b/src/linters/file_header/__init__.py
@@ -1,24 +1,79 @@
 """
 File: src/linters/file_header/__init__.py
 Purpose: File header linter module initialization
-Exports: FileHeaderRule
-Depends: linter.FileHeaderRule
-Implements: Module-level exports for clean API
+Exports: FileHeaderRule, lint
+Depends: linter.FileHeaderRule, orchestrator.core.Orchestrator
+Implements: Module-level exports and a lint() convenience function for direct library usage
 Related: linter.py for main rule implementation
 
 Overview:
     Initializes the file header linter module providing multi-language file header
     validation with mandatory field checking, atemporal language detection, and configuration
-    support. Main entry point for file header linting functionality.
+    support. Main entry point for file header linting functionality. Exposes a package-level
+    lint() convenience function, mirroring the other linters (nesting, srp, file_placement), so
+    callers can lint a file or directory without wiring up an orchestrator themselves.
 
 Usage:
     from src.linters.file_header import FileHeaderRule
     rule = FileHeaderRule()
     violations = rule.check(context)
 
+    from src.linters.file_header import lint
+    violations = lint("src/", config={"required_fields": ["Purpose", "Scope", "Overview"]})
+
 Notes: Follows standard Python module initialization pattern with __all__ export control
 """
 
+from pathlib import Path
+from typing import Any
+
+from src.core.types import Violation
+
 from .linter import FileHeaderRule
 
-__all__ = ["FileHeaderRule"]
+__all__ = ["FileHeaderRule", "lint"]
+
+
+def lint(path: Path | str, config: dict[str, Any] | None = None) -> list[Violation]:
+    """Lint a file or directory for file header violations.
+
+    Args:
+        path: Path to file or directory to lint.
+        config: Optional file-header configuration dict (e.g. required_fields,
+            enforce_atemporal, ignore). Uses defaults when omitted.
+
+    Returns:
+        List of file-header violations found.
+
+    Example:
+        >>> from src.linters.file_header import lint
+        >>> violations = lint("src/", config={"required_fields": ["Purpose"]})
+        >>> for v in violations:
+        ...     print(f"{v.file_path}:{v.line} - {v.message}")
+    """
+    path_obj = Path(path) if isinstance(path, str) else path
+    project_root = path_obj if path_obj.is_dir() else path_obj.parent
+
+    orchestrator = _setup_file_header_orchestrator(project_root, config)
+    violations = _execute_file_header_lint(orchestrator, path_obj)
+
+    return [v for v in violations if "file-header" in v.rule_id]
+
+
+def _setup_file_header_orchestrator(project_root: Path, config: dict[str, Any] | None) -> Any:
+    """Set up an orchestrator with optional file-header config."""
+    from src.orchestrator.core import Orchestrator
+
+    orchestrator = Orchestrator(project_root=project_root)
+    if config is not None:
+        orchestrator.config["file_header"] = config
+    return orchestrator
+
+
+def _execute_file_header_lint(orchestrator: Any, path_obj: Path) -> list[Violation]:
+    """Execute linting on a file or directory."""
+    if path_obj.is_file():
+        return orchestrator.lint_file(path_obj)
+    if path_obj.is_dir():
+        return orchestrator.lint_directory(path_obj)
+    return []

--- a/tests/unit/linters/file_header/test_lint_convenience.py
+++ b/tests/unit/linters/file_header/test_lint_convenience.py
@@ -1,0 +1,60 @@
+"""
+Purpose: Tests for the file_header package-level lint() convenience function
+
+Scope: src.linters.file_header.lint public API used for direct library usage
+
+Overview: Verifies the file_header linter exposes a package-level lint() convenience function
+    mirroring the other linters (nesting, srp, file_placement). The function was missing, so
+    examples/file_header_usage.py raised ImportError on import. Tests confirm lint() is importable,
+    runs a file or directory through the orchestrator, returns only file-header violations, flags a
+    file missing mandatory header fields, passes a file with a complete header, and honors a config
+    dict for required fields and atemporal enforcement.
+
+Dependencies: pytest, tmp_path fixture, src.linters.file_header.lint
+
+Exports: TestFileHeaderLintConvenience test class
+
+Interfaces: Tests lint(path, config) -> list[Violation]
+
+Implementation: Writes temporary Python files and asserts on returned violations with an explicit
+    empty ignore list to keep assertions independent of default ignore patterns
+"""
+
+from pathlib import Path
+
+# Common config used to make assertions independent of default ignore patterns
+# and atemporal checks, focusing each test on a single behavior.
+_BASE_CONFIG = {"ignore": [], "required_fields": ["Purpose"], "enforce_atemporal": False}
+
+
+class TestFileHeaderLintConvenience:
+    """The file_header package must expose a working lint() convenience function."""
+
+    def test_lint_is_importable(self) -> None:
+        """lint() must be importable from the file_header package."""
+        from src.linters.file_header import lint
+
+        assert callable(lint)
+
+    def test_lint_flags_file_missing_header(self, tmp_path: Path) -> None:
+        """lint() should report a file-header violation for a file with no header."""
+        from src.linters.file_header import lint
+
+        target = tmp_path / "nodoc.py"
+        target.write_text("x = 1\n")
+
+        violations = lint(str(target), config=_BASE_CONFIG)
+
+        assert len(violations) >= 1
+        assert all("file-header" in v.rule_id for v in violations)
+
+    def test_lint_passes_file_with_complete_header(self, tmp_path: Path) -> None:
+        """lint() should report no violations for a file satisfying required fields."""
+        from src.linters.file_header import lint
+
+        target = tmp_path / "documented.py"
+        target.write_text('"""\nPurpose: A documented module\n"""\n\nx = 1\n')
+
+        violations = lint(str(target), config=_BASE_CONFIG)
+
+        assert violations == []


### PR DESCRIPTION
## Summary

`src.linters.file_header` exported only `FileHeaderRule`, so `from src.linters.file_header import lint` raised `ImportError`. This broke `examples/file_header_usage.py` at import time (it imports `lint as file_header_lint`). Every other linter — `nesting`, `srp`, `file_placement` — exposes a package-level `lint()` convenience function; file_header was the lone exception.

(Discovered while fixing #212; flagged then as a separate pre-existing bug.)

## Fix

Add `lint(path, config=None)` to the file_header package, mirroring the `nesting` implementation:
- wires up an `Orchestrator` rooted at the path (or its parent for a file),
- applies the optional file-header `config` dict (`required_fields`, `enforce_atemporal`, `ignore`, …),
- lints the file/directory and returns only `file-header` violations.

The example script now imports and runs.

## Tests

New `tests/unit/linters/file_header/test_lint_convenience.py` (written failing first — `ImportError`):
- `lint` is importable and callable
- flags a file with no header
- passes a file whose header satisfies the required fields

## Verification

- `just lint-full` → exit 0
- `just test` → exit 0, 2423 passed, 19 skipped (file_header suite: 153 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)