### PR TITLE
fix: parse TypeScript file once in DRY analyzer instead of per window (#222)

### DIFF
--- a/src/linters/dry/typescript_analyzer.py
+++ b/src/linters/dry/typescript_analyzer.py
@@ -45,7 +45,12 @@ from .base_token_analyzer import BaseTokenAnalyzer
 from .block_filter import BlockFilterRegistry, create_default_registry
 from .cache import CodeBlock
 from .config import DRYConfig
-from .typescript_statement_detector import is_single_statement, should_include_block
+from .typescript_statement_detector import (
+    block_overlaps_interface,
+    find_interface_ranges,
+    is_single_statement_for_root,
+    parse_root,
+)
 
 if TREE_SITTER_AVAILABLE:
     from tree_sitter import Node
@@ -82,8 +87,13 @@ class TypeScriptDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.vi
         Returns:
             List of CodeBlock instances with hash values
         """
-        # Get JSDoc comment line ranges
-        jsdoc_ranges = self._get_jsdoc_ranges_from_content(content)
+        # Parse the file's AST once and reuse it for every window (issue #222): the previous
+        # implementation re-parsed the whole file and re-scanned interface ranges per window,
+        # making analysis O(windows x filesize) and pegging a core on large/minified bundles.
+        root = parse_root(content)
+
+        # Get JSDoc comment line ranges from the shared AST
+        jsdoc_ranges = self._get_jsdoc_ranges_from_root(root)
 
         # Tokenize with line number tracking, skipping JSDoc lines
         lines_with_numbers = self._tokenize_with_line_numbers(content, jsdoc_ranges)
@@ -91,12 +101,15 @@ class TypeScriptDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.vi
         # Generate rolling hash windows
         windows = self._rolling_hash_with_tracking(lines_with_numbers, config.min_duplicate_lines)
 
+        # Compute interface/type definition ranges once, then reuse across all windows
+        interface_ranges = find_interface_ranges(content)
+
         # Filter out interface/type definitions and single statement patterns
         valid_windows = (
             (hash_val, start_line, end_line, snippet)
             for hash_val, start_line, end_line, snippet in windows
-            if should_include_block(content, start_line, end_line)
-            and not is_single_statement(content, start_line, end_line)
+            if not block_overlaps_interface(start_line, end_line, interface_ranges)
+            and not is_single_statement_for_root(root, start_line, end_line)
         )
         return self._build_blocks(valid_windows, file_path, content)
 
@@ -129,23 +142,16 @@ class TypeScriptDuplicateAnalyzer(BaseTokenAnalyzer):  # thailint: ignore[srp.vi
                 blocks.append(block)
         return blocks
 
-    def _get_jsdoc_ranges_from_content(self, content: str) -> set[int]:
-        """Extract line numbers that are part of JSDoc comments.
+    def _get_jsdoc_ranges_from_root(self, root: Node | None) -> set[int]:
+        """Extract line numbers that are part of JSDoc comments from a parsed AST.
 
         Args:
-            content: TypeScript/JavaScript source code
+            root: Tree-sitter root node from parse_root(), or None
 
         Returns:
             Set of line numbers (1-indexed) that are part of JSDoc comments
         """
-        if not TREE_SITTER_AVAILABLE:
-            return set()
-
-        from src.analyzers.typescript_base import TypeScriptBaseAnalyzer
-
-        analyzer = TypeScriptBaseAnalyzer()
-        root = analyzer.parse_typescript(content)
-        if not root:
+        if root is None:
             return set()
 
         jsdoc_lines: set[int] = set()

--- a/src/linters/dry/typescript_statement_detector.py
+++ b/src/linters/dry/typescript_statement_detector.py
@@ -10,10 +10,14 @@ Overview: Provides sophisticated single-statement pattern detection to filter fa
 
 Dependencies: tree-sitter for TypeScript AST parsing
 
-Exports: is_single_statement, should_include_block functions
+Exports: parse_root, is_single_statement, is_single_statement_for_root, should_include_block,
+    find_interface_ranges, block_overlaps_interface functions
 
-Interfaces: is_single_statement(content, start_line, end_line) -> bool,
-    should_include_block(content, start_line, end_line) -> bool
+Interfaces: parse_root(content) -> Node | None, is_single_statement(content, start, end) -> bool,
+    is_single_statement_for_root(root, start, end) -> bool,
+    should_include_block(content, start, end) -> bool,
+    find_interface_ranges(content) -> list[tuple[int, int]],
+    block_overlaps_interface(start, end, interface_ranges) -> bool
 
 Implementation: Tree-sitter AST walking with pattern matching for TypeScript constructs
 
@@ -32,6 +36,27 @@ else:
     Node = Any  # type: ignore[assignment,misc]
 
 
+def parse_root(content: str) -> Node | None:
+    """Parse TypeScript/JavaScript content into a tree-sitter root node.
+
+    Intended to be called once per file so the resulting AST can be reused across
+    every rolling-hash window instead of re-parsing the file each time.
+
+    Args:
+        content: TypeScript source code
+
+    Returns:
+        Tree-sitter root node, or None if tree-sitter is unavailable or parsing fails
+    """
+    if not TREE_SITTER_AVAILABLE:
+        return None
+
+    from src.analyzers.typescript_base import TypeScriptBaseAnalyzer
+
+    analyzer = TypeScriptBaseAnalyzer()
+    return analyzer.parse_typescript(content)
+
+
 def is_single_statement(content: str, start_line: int, end_line: int) -> bool:
     """Check if a line range is a single logical statement.
 
@@ -43,14 +68,21 @@ def is_single_statement(content: str, start_line: int, end_line: int) -> bool:
     Returns:
         True if this range represents a single logical statement/expression
     """
-    if not TREE_SITTER_AVAILABLE:
-        return False
+    return is_single_statement_for_root(parse_root(content), start_line, end_line)
 
-    from src.analyzers.typescript_base import TypeScriptBaseAnalyzer
 
-    analyzer = TypeScriptBaseAnalyzer()
-    root = analyzer.parse_typescript(content)
-    if not root:
+def is_single_statement_for_root(root: Node | None, start_line: int, end_line: int) -> bool:
+    """Check a line range against an already-parsed AST root.
+
+    Args:
+        root: Tree-sitter root node from parse_root(), or None
+        start_line: Starting line number (1-indexed)
+        end_line: Ending line number (1-indexed)
+
+    Returns:
+        True if this range represents a single logical statement/expression
+    """
+    if root is None:
         return False
 
     return _check_overlapping_nodes(root, start_line, end_line)
@@ -67,8 +99,7 @@ def should_include_block(content: str, start_line: int, end_line: int) -> bool:
     Returns:
         False if block overlaps interface definition, True otherwise
     """
-    interface_ranges = _find_interface_ranges(content)
-    return not _overlaps_interface(start_line, end_line, interface_ranges)
+    return not block_overlaps_interface(start_line, end_line, find_interface_ranges(content))
 
 
 def _check_overlapping_nodes(root: Node, start_line: int, end_line: int) -> bool:
@@ -197,8 +228,11 @@ def _is_in_class_field_area(class_body: Node, ts_start: int, ts_end: int) -> boo
     return class_start <= ts_start and ts_end < first_method_line
 
 
-def _find_interface_ranges(content: str) -> list[tuple[int, int]]:
-    """Find line ranges of interface/type definitions."""
+def find_interface_ranges(content: str) -> list[tuple[int, int]]:
+    """Find line ranges of interface/type definitions.
+
+    Intended to be called once per file so the ranges can be reused across windows.
+    """
     ranges: list[tuple[int, int]] = []
     lines = content.split("\n")
     state = {"in_interface": False, "start_line": 0, "brace_count": 0}
@@ -250,6 +284,6 @@ def _handle_interface_continuation(
         state["in_interface"] = False
 
 
-def _overlaps_interface(start: int, end: int, interface_ranges: list[tuple[int, int]]) -> bool:
+def block_overlaps_interface(start: int, end: int, interface_ranges: list[tuple[int, int]]) -> bool:
     """Check if block overlaps with any interface range."""
     return any(start <= if_end and end >= if_start for if_start, if_end in interface_ranges)

--- a/tests/unit/linters/dry/test_typescript_parse_once.py
+++ b/tests/unit/linters/dry/test_typescript_parse_once.py
@@ -1,0 +1,64 @@
+"""
+Purpose: Regression test for TypeScript DRY analyzer per-window re-parsing (issue #222)
+
+Scope: TypeScriptDuplicateAnalyzer.analyze tree-sitter parse + interface-range scaling
+
+Overview: Guards against the O(windows x filesize) blow-up reported in issue #222, where the
+    TypeScript block analyzer re-parsed the entire file with tree-sitter (and re-scanned the whole
+    file for interface ranges) once per rolling-hash window, pegging a core for minutes on large or
+    minified JS bundles. Verifies the analyzer now parses each file's AST a single time and computes
+    interface ranges a single time, reused across every window, by counting tree-sitter parse calls
+    during one analyze() run on a multi-window input. Pairs with the existing TypeScript DRY suite,
+    which pins the unchanged detection behavior.
+
+Dependencies: pytest, unittest.mock, pathlib.Path, src.analyzers.typescript_base,
+    src.linters.dry.typescript_analyzer, src.linters.dry.config
+
+Exports: TestTypeScriptParseOnce test class
+
+Interfaces: Tests TypeScriptDuplicateAnalyzer.analyze(file_path, content, config) -> list[CodeBlock]
+
+Implementation: Wraps TypeScriptBaseAnalyzer.parse_typescript with a call counter and asserts it runs
+    a constant number of times independent of the number of rolling-hash windows
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.analyzers.typescript_base import TREE_SITTER_AVAILABLE, TypeScriptBaseAnalyzer
+from src.linters.dry.config import DRYConfig
+from src.linters.dry.typescript_analyzer import TypeScriptDuplicateAnalyzer
+
+pytestmark = pytest.mark.skipif(not TREE_SITTER_AVAILABLE, reason="tree-sitter not available")
+
+# Enough distinct lines to generate many rolling-hash windows from one file.
+MANY_LINES = 120
+
+
+class TestTypeScriptParseOnce:
+    """The TS analyzer must parse each file once, not once per window (issue #222)."""
+
+    def test_analyze_parses_file_a_constant_number_of_times(self) -> None:
+        """analyze() must not re-parse the whole file per rolling-hash window."""
+        content = "\n".join(
+            f"const value{i} = compute({i}, {i + 1}, {i + 2});" for i in range(MANY_LINES)
+        )
+        analyzer = TypeScriptDuplicateAnalyzer()
+        config = DRYConfig(enabled=True, min_duplicate_lines=4)
+
+        original = TypeScriptBaseAnalyzer.parse_typescript
+        parse_calls = 0
+
+        def counting(self, code):  # noqa: ANN001
+            nonlocal parse_calls
+            parse_calls += 1
+            return original(self, code)
+
+        with patch.object(TypeScriptBaseAnalyzer, "parse_typescript", counting):
+            analyzer.analyze(Path("big.ts"), content, config)
+
+        # One parse for the file is enough; the previous code parsed once per window
+        # (~117 windows here). Allow a small constant for incidental parses.
+        assert parse_calls <= 2, f"expected a constant number of parses, got {parse_calls}"


### PR DESCRIPTION
## Summary

Fixes #222 — the next DRY bottleneck after #213. The TypeScript block analyzer re-processed the **entire file per rolling-hash window**:

- `is_single_statement(content, …)` ran a full tree-sitter **parse** + AST walk of the whole file
- `should_include_block(content, …)` re-scanned the whole file for **interface ranges**

That's **O(windows × filesize)** per file. py-spy showed ~85% of a full-codebase run sitting on the per-window parse (`typescript_statement_detector.py:52`), pegging a core for minutes on large/minified JS bundles.

## Fix

Parse each file's AST **once** and compute interface ranges **once** in `TypeScriptDuplicateAnalyzer.analyze()`, then reuse across every window:

- add `parse_root()` (single shared parse) and `is_single_statement_for_root(root, …)` to the detector; the content-based `is_single_statement()` now delegates to them
- expose `find_interface_ranges()` / `block_overlaps_interface()` and compute the ranges once before the window loop
- reuse the single parsed root for JSDoc extraction too → **one parse per file total** (was 1 + one per window)

Behavior-preserving: per-window results are identical, so detection output is unchanged.

## Tests

- New `tests/unit/linters/dry/test_typescript_parse_once.py`: counts tree-sitter parses during one `analyze()` on a 120-line input. Was **118** parses (≈one per window); now **1**. Written failing first.
- Behavior pinned by the existing TypeScript DRY suite — **all 103 DRY tests pass**.

## Verification

- `just lint-full` → exit 0
- `just test` → exit 0, 2424 passed, 19 skipped

## Follow-up (not in this PR)

The per-window AST walk in `is_single_statement_for_root` remains O(nodes) per window (with short-circuit). The profile showed the **parse** was the dominant cost, so this isn't hot, but indexing single-statement node ranges by line for O(windows·log n) is a possible future optimization (report's bullet 3). Optionally default-ignoring `*.min.js`/vendored assets is also worth considering separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)