### PR TITLE
chore: Publish v0.19.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI](https://img.shields.io/badge/pypi-v0.19.5-orange)](https://pypi.org/project/thailint/)
-[![Tests](https://img.shields.io/badge/tests-2442%2F2442%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
+[![PyPI](https://img.shields.io/badge/pypi-v0.19.6-orange)](https://pypi.org/project/thailint/)
+[![Tests](https://img.shields.io/badge/tests-2443%2F2443%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
 [![Documentation](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.19.5"
+version = "0.19.6"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.19.6
- Updated poetry.lock / README badges

Captures the Publish workflow's working-tree changes; opened manually because Actions can't create PRs (repo setting still off).

## Published
- PyPI: https://pypi.org/project/thailint/0.19.6/
- Docker Hub: tags `0.19.6`, `latest`

## What 0.19.6 adds over 0.19.5
- DRY TypeScript analyzer parses each file once instead of per rolling-hash window — fixes O(windows×filesize) hang on large/minified JS (#222)

🤖 Generated with [Claude Code](https://claude.com/claude-code)