### PR TITLE
chore: Publish v0.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![PyPI](https://img.shields.io/badge/pypi-v0.19.6-orange)](https://pypi.org/project/thailint/)
-[![Tests](https://img.shields.io/badge/tests-2443%2F2443%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
+[![PyPI](https://img.shields.io/badge/pypi-v0.20.0-orange)](https://pypi.org/project/thailint/)
+[![Tests](https://img.shields.io/badge/tests-2464%2F2464%20passing-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint/actions)
 [![Coverage](https://img.shields.io/badge/coverage-91%25-brightgreen.svg)](https://github.com/be-wise-be-kind/thai-lint)
 [![Documentation](https://readthedocs.org/projects/thai-lint/badge/?version=latest)](https://thai-lint.readthedocs.io/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "thailint"
-version = "0.19.6"
+version = "0.20.0"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Version bump to 0.20.0
- Updated poetry.lock
- Updated README badges (version, tests, coverage)

## Published to
- PyPI: https://pypi.org/project/thailint/0.20.0/
- Docker Hub: `thailint:0.20.0` and `:latest`

Captures the changes made by the `Publish` workflow. The workflow published to PyPI and Docker Hub successfully; it could not open this PR itself because GitHub Actions is not permitted to create PRs in this repo, so it was opened manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)