### PR TITLE
chore: add Melvin Caraang and Gabriel Acosta as maintainers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,10 @@ name = "thailint"
 version = "0.19.6"
 description = "The AI Linter - Enterprise-grade linting and governance for AI-generated code across multiple languages"
 authors = ["Steve Jackson"]
+maintainers = [
+    "Melvin Caraang",
+    "Gabriel Acosta",
+]
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/be-wise-be-kind/thai-lint"


### PR DESCRIPTION
Add maintainers field to pyproject.toml for PyPI metadata.

- Melvin Caraang
- Gabriel Acosta

[Warp conversation](https://app.warp.dev/conversation/82ca34f6-4146-48da-bb96-0c676d45c1d3)

Co-Authored-By: Oz <oz-agent@warp.dev>