### PR TITLE
feat(pre-commit): add .pre-commit-hooks.yaml manifest for repo consumption

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -20,26 +20,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 2.1.4
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-
-      - name: Install project
-        run: poetry install --no-interaction
+      - name: Install pre-commit
+        run: pip install pre-commit
 
       - name: Install just
         uses: extractions/setup-just@v2

--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -1,0 +1,48 @@
+name: Dogfood
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  dogfood:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          version: 2.1.4
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Dogfood the pre-commit manifest (just dogfood)
+        run: just dogfood

--- a/.pre-commit-config.dogfood.yaml
+++ b/.pre-commit-config.dogfood.yaml
@@ -1,0 +1,80 @@
+# Purpose: Dogfooding harness that runs thai-lint's own published .pre-commit-hooks.yaml against its source
+# Scope: Local `just dogfood` runs and the dogfood CI workflow, exercising the manifest end to end
+# Overview: Consumes the repo-root .pre-commit-hooks.yaml the same way an external consumer would — through
+#     a remote `repo:` reference — but points at this repository itself (`repo: .`) so the manifest is
+#     validated without requiring a published release tag. The `just dogfood` recipe rewrites the `rev`
+#     to the current commit SHA before running, which pins an immutable reference and avoids pre-commit's
+#     mutable-reference caching. Each hook scans `src/` with the project configuration, mirroring
+#     `just lint-full` so the dogfood results match the canonical quality gate. Cross-file linters
+#     (SRP, stringly-typed, DRY) run with `--parallel` to match that gate.
+# Dependencies: pre-commit, the repo-root .pre-commit-hooks.yaml manifest, .thailint.yaml, the thailint package
+# Exports: Dogfood hook configuration consumed by `just dogfood` and .github/workflows/dogfood.yml
+# Interfaces: Invoked via `just dogfood`; run as a CI gate on pull requests and pushes to main
+# Environment: Development and CI; builds thailint in an isolated pre-commit environment from this repo
+# Related: .pre-commit-hooks.yaml (published manifest), .pre-commit-config.yaml, justfile, docs/pre-commit-hooks.md
+# Implementation: repo: . with a rev rewritten to HEAD's SHA; hooks pinned to src/ scope with .thailint.yaml
+
+repos:
+  - repo: .
+    rev: HEAD # rewritten to the current commit SHA by `just dogfood` (do not run this file directly)
+    hooks:
+      - id: thailint-file-placement
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-file-header
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-nesting
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-srp
+        args: [src/, --config, .thailint.yaml, --parallel]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-magic-numbers
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-method-property
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-improper-logging
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-lazy-ignores
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-lbyl
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-law-of-demeter
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-pipeline
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-stateless-class
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-stringly-typed
+        args: [src/, --config, .thailint.yaml, --parallel]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-perf
+        args: [src/, --config, .thailint.yaml]
+        pass_filenames: false
+        always_run: true
+      - id: thailint-dry
+        args: [src/, --config, .thailint.yaml, --parallel]
+        pass_filenames: false
+        always_run: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,150 @@
+# Purpose: Pre-commit hook manifest so thai-lint is consumable as a pinned `repo:` hook source
+# Scope: Downstream repositories that wire thai-lint linters into pre-commit or prek workflows
+# Overview: Declares every stable thai-lint linter as a standalone `language: python` hook so
+#     consumers can pin a `rev:` and enable individual checks via
+#     `repo: https://github.com/be-wise-be-kind/thai-lint`. The hook framework creates an
+#     isolated environment, installs thailint from the pinned revision, and runs the `thailint`
+#     console script, removing any dependency on a pre-installed CLI or a particular runner
+#     (poetry/uv/pipx). Each hook passes changed files to its linter and restricts execution to
+#     the file types that linter supports via `types_or`. Consumers supply their own `args`
+#     (for example `--config` or `--max-depth`) when enabling a hook.
+# Dependencies: pre-commit or prek, a Python toolchain capable of building thailint from source
+# Exports: Individual `thailint-*` hook definitions covering source-quality and Rust linters
+# Interfaces: Consumed by pre-commit/prek via the repository `repo:` key; each hook runs
+#     `thailint <command>` against staged files
+# Environment: Any environment where the hook framework can build and install thailint
+# Related: .pre-commit-config.yaml (this repository's own hooks), docs/pre-commit-hooks.md
+# Implementation: One `language: python` hook per CLI linter command, with `types_or` filters
+#     matching each linter's documented language support
+
+- id: thailint-file-placement
+  name: thai-lint file placement
+  description: Lint files for proper file placement
+  entry: thailint file-placement
+  language: python
+
+- id: thailint-file-header
+  name: thai-lint file headers
+  description: Check file headers for mandatory fields and atemporal language
+  entry: thailint file-header
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-nesting
+  name: thai-lint nesting depth
+  description: Check for excessive nesting depth in code
+  entry: thailint nesting
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx, rust]
+
+- id: thailint-srp
+  name: thai-lint SRP
+  description: Check for Single Responsibility Principle violations
+  entry: thailint srp
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-dry
+  name: thai-lint DRY
+  description: Check for duplicate code (DRY principle violations)
+  entry: thailint dry
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-magic-numbers
+  name: thai-lint magic numbers
+  description: Check for magic numbers in code
+  entry: thailint magic-numbers
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx, rust]
+
+- id: thailint-method-property
+  name: thai-lint method property
+  description: Check for methods that should be @property decorators
+  entry: thailint method-property
+  language: python
+  types_or: [python, ts, tsx]
+
+- id: thailint-improper-logging
+  name: thai-lint improper logging
+  description: Check for improper logging patterns in code
+  entry: thailint improper-logging
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-lazy-ignores
+  name: thai-lint lazy ignores
+  description: Check for unjustified linting suppressions
+  entry: thailint lazy-ignores
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx, rust]
+
+- id: thailint-lbyl
+  name: thai-lint LBYL
+  description: Check for Look Before You Leap anti-patterns
+  entry: thailint lbyl
+  language: python
+  types_or: [python]
+
+- id: thailint-law-of-demeter
+  name: thai-lint Law of Demeter
+  description: Check for Law of Demeter violations
+  entry: thailint law-of-demeter
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-pipeline
+  name: thai-lint collection pipeline
+  description: Check for collection pipeline anti-patterns in code
+  entry: thailint pipeline
+  language: python
+  types_or: [python, ts, tsx]
+
+- id: thailint-stateless-class
+  name: thai-lint stateless class
+  description: Check for stateless classes that should be module functions
+  entry: thailint stateless-class
+  language: python
+  types_or: [python, ts, tsx]
+
+- id: thailint-stringly-typed
+  name: thai-lint stringly-typed
+  description: Check for stringly-typed patterns in code
+  entry: thailint stringly-typed
+  language: python
+  types_or: [python, ts, tsx, javascript, jsx]
+
+- id: thailint-perf
+  name: thai-lint performance
+  description: Check for performance anti-patterns in code
+  entry: thailint perf
+  language: python
+  types_or: [python, ts, tsx]
+
+- id: thailint-version-freshness
+  name: thai-lint version freshness
+  description: Check runtime/infrastructure versions for EOL and outdated releases
+  entry: thailint version-freshness
+  language: python
+  types_or: [dockerfile, terraform, yaml, toml]
+
+- id: thailint-blocking-async
+  name: thai-lint blocking async (Rust)
+  description: Check for blocking operations in async Rust functions
+  entry: thailint blocking-async
+  language: python
+  types_or: [rust]
+
+- id: thailint-clone-abuse
+  name: thai-lint clone abuse (Rust)
+  description: Check for .clone() abuse patterns in Rust code
+  entry: thailint clone-abuse
+  language: python
+  types_or: [rust]
+
+- id: thailint-unwrap-abuse
+  name: thai-lint unwrap abuse (Rust)
+  description: Check for .unwrap() and .expect() abuse in Rust code
+  entry: thailint unwrap-abuse
+  language: python
+  types_or: [rust]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Pre-commit hooks manifest** - Ship `.pre-commit-hooks.yaml` so thai-lint is consumable as a pinned `repo:` hook source ([#229](https://github.com/be-wise-be-kind/thai-lint/issues/229))
+  - Declares all 19 stable linters as `language: python` hooks, each scoped to its supported file types via `types_or`
+  - Lets consumers pin a `rev:` and run thai-lint under pre-commit or prek with no pre-installed CLI and no runner assumption
+  - Documents `repo:` consumption alongside the existing local-hook patterns in `docs/pre-commit-hooks.md`
+
 ## [0.19.1] - 2026-05-11
 
 ### Fixed

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -312,6 +312,39 @@ pre-commit run --files src/cli.py
 
 ## Using thai-lint in Pre-commit Hooks
 
+### Recommended: Consume via `repo:` (pinned, self-installing)
+
+thai-lint ships a `.pre-commit-hooks.yaml` manifest at its repository root, so you can consume its linters directly from the repository. The hook framework creates an isolated environment, installs thai-lint from the revision you pin, and runs the `thailint` console script. This requires no pre-installed CLI and no particular runner (poetry/uv/pipx), and it pins the version so every contributor and CI run uses the same thai-lint.
+
+```yaml
+repos:
+  - repo: https://github.com/be-wise-be-kind/thai-lint
+    rev: v0.20.2          # pin to a released tag
+    hooks:
+      - id: thailint-file-header
+      - id: thailint-nesting
+        args: [--max-depth, "3"]            # pass linter flags via args
+      - id: thailint-srp
+      - id: thailint-magic-numbers
+        args: [--config, .thailint.yaml]    # point at your config
+```
+
+Each hook passes the staged files to its linter and restricts execution to the file types that linter supports. This format works under both [pre-commit](https://pre-commit.com/) and [prek](https://github.com/j178/prek).
+
+**Available hook ids:**
+
+| Category | Hook ids |
+|----------|----------|
+| Source quality | `thailint-file-placement`, `thailint-file-header`, `thailint-nesting`, `thailint-srp`, `thailint-dry`, `thailint-magic-numbers`, `thailint-method-property`, `thailint-improper-logging`, `thailint-lazy-ignores`, `thailint-lbyl`, `thailint-law-of-demeter`, `thailint-pipeline`, `thailint-stateless-class`, `thailint-stringly-typed`, `thailint-perf` |
+| Infrastructure | `thailint-version-freshness` |
+| Rust | `thailint-blocking-async`, `thailint-clone-abuse`, `thailint-unwrap-abuse` |
+
+Enable only the hook ids you want. Supply linter flags (such as `--config` or `--max-depth`) through each hook's `args` key.
+
+### Alternative: Local hooks against an installed CLI
+
+The `repo: local` patterns below remain valid when you prefer to run an already-installed thai-lint (for example to share one virtualenv with other tooling). These shell out to the CLI via `language: system` and depend on thai-lint being on `PATH`.
+
 ### Basic thai-lint Hook
 
 Add thai-lint to your `.pre-commit-config.yaml`:

--- a/justfile
+++ b/justfile
@@ -718,6 +718,17 @@ format:
     @poetry run ruff format src/ tests/
     @poetry run ruff check --fix src/ tests/
 
+# Dogfood the published .pre-commit-hooks.yaml manifest against src/ (mirrors lint-full via the manifest)
+dogfood:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo -e "{{BLUE}}{{BOLD}}🐶 Dogfooding .pre-commit-hooks.yaml manifest against src/...{{NC}}"
+    rev=$(git rev-parse HEAD)
+    cfg=$(mktemp)
+    trap 'rm -f "$cfg"' EXIT
+    sed "s/rev: HEAD/rev: $rev/" .pre-commit-config.dogfood.yaml > "$cfg"
+    poetry run pre-commit run --config "$cfg" --all-files
+
 # Run tests (parallel by default for speed, use --serial for reliability)
 test *ARGS="":
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -727,7 +727,7 @@ dogfood:
     cfg=$(mktemp)
     trap 'rm -f "$cfg"' EXIT
     sed "s/rev: HEAD/rev: $rev/" .pre-commit-config.dogfood.yaml > "$cfg"
-    poetry run pre-commit run --config "$cfg" --all-files
+    pre-commit run --config "$cfg" --all-files
 
 # Run tests (parallel by default for speed, use --serial for reliability)
 test *ARGS="":

--- a/tests/unit/test_pre_commit_hooks_manifest.py
+++ b/tests/unit/test_pre_commit_hooks_manifest.py
@@ -1,0 +1,128 @@
+"""Unit tests validating the .pre-commit-hooks.yaml consumer manifest.
+
+Purpose: Guarantee the repo-root .pre-commit-hooks.yaml stays valid and consumable as a
+    pre-commit/prek `repo:` hook source
+
+Scope: Structural and semantic validation of the .pre-commit-hooks.yaml manifest shipped at
+    the repository root for downstream consumers
+
+Overview: thai-lint ships a .pre-commit-hooks.yaml manifest so other repositories can pin and
+    consume its linters via `repo: https://github.com/be-wise-be-kind/thai-lint`. This module
+    validates that manifest end to end: it parses as a YAML list of hook mappings, every hook
+    declares the mandatory pre-commit fields, every hook installs as a `language: python` hook,
+    hook ids are unique and namespaced under `thailint-`, and every hook `entry` invokes the
+    real `thailint` console script with a subcommand that is actually registered on the CLI.
+    These checks prevent shipping a manifest that references a removed command or a malformed
+    hook definition.
+
+Dependencies: pytest for testing, PyYAML for manifest parsing, src.cli for the registered
+    command set
+
+Exports: Test classes covering manifest structure, hook field requirements, and command
+    coverage
+
+Interfaces: Reads .pre-commit-hooks.yaml from the repository root and inspects src.cli.cli
+    Click command registry
+
+Implementation: Loads the manifest once, then asserts per-hook invariants and cross-checks
+    each entry subcommand against the live Click command group
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.cli import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / ".pre-commit-hooks.yaml"
+
+REQUIRED_FIELDS = ("id", "name", "entry", "language")
+
+
+def _load_manifest():
+    """Parse the .pre-commit-hooks.yaml manifest into a list of hook mappings."""
+    with MANIFEST_PATH.open(encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _has_valid_types_or(hook):
+    """Return True when the hook omits types_or or declares a non-empty list of strings."""
+    if "types_or" not in hook:
+        return True
+    tags = hook["types_or"]
+    return isinstance(tags, list) and bool(tags) and all(isinstance(tag, str) for tag in tags)
+
+
+@pytest.fixture(scope="module")
+def hooks():
+    """Return the parsed list of hook definitions from the manifest."""
+    return _load_manifest()
+
+
+class TestManifestStructure:
+    """Validate the top-level shape of the manifest."""
+
+    def test_manifest_exists(self):
+        """Manifest must exist at the repository root for `repo:` consumption."""
+        assert MANIFEST_PATH.is_file()
+
+    def test_manifest_is_nonempty_list(self, hooks):
+        """Manifest must be a non-empty list of hook mappings."""
+        assert isinstance(hooks, list)
+        assert hooks
+        assert all(isinstance(hook, dict) for hook in hooks)
+
+    def test_hook_ids_are_unique(self, hooks):
+        """Duplicate hook ids would make hooks unselectable by consumers."""
+        ids = [hook["id"] for hook in hooks]
+        assert len(ids) == len(set(ids))
+
+
+class TestHookFields:
+    """Validate required fields on every hook definition."""
+
+    def test_all_hooks_have_required_fields(self, hooks):
+        """Every hook must declare id, name, entry, and language."""
+        for hook in hooks:
+            for field in REQUIRED_FIELDS:
+                assert field in hook, f"hook {hook.get('id')!r} missing {field!r}"
+
+    def test_all_hooks_are_language_python(self, hooks):
+        """Hooks must install as language: python for runner-agnostic, pinnable use."""
+        for hook in hooks:
+            assert hook["language"] == "python", hook["id"]
+
+    def test_all_hook_ids_are_thailint_namespaced(self, hooks):
+        """Hook ids must be namespaced under thailint- to avoid consumer collisions."""
+        for hook in hooks:
+            assert hook["id"].startswith("thailint-"), hook["id"]
+
+    def test_types_or_filters_are_string_lists(self, hooks):
+        """When present, types_or must be a non-empty list of identify tag strings."""
+        invalid = [hook["id"] for hook in hooks if not _has_valid_types_or(hook)]
+        assert not invalid, invalid
+
+
+class TestEntryCommandCoverage:
+    """Cross-check hook entries against the live CLI command registry."""
+
+    def test_entries_invoke_thailint_console_script(self, hooks):
+        """Every entry must invoke the `thailint` console script."""
+        for hook in hooks:
+            assert hook["entry"].split()[0] == "thailint", hook["id"]
+
+    def test_entry_subcommands_are_registered(self, hooks):
+        """Each entry subcommand must be a real, registered CLI command."""
+        registered = set(cli.commands.keys())
+        for hook in hooks:
+            subcommand = hook["entry"].split()[1]
+            assert subcommand in registered, f"{hook['id']}: unknown command {subcommand!r}"
+
+    def test_no_deprecated_commands_referenced(self, hooks):
+        """Manifest must not surface deprecated aliases to consumers."""
+        deprecated = {"print-statements"}
+        for hook in hooks:
+            subcommand = hook["entry"].split()[1]
+            assert subcommand not in deprecated, hook["id"]


### PR DESCRIPTION
## Summary

Fixes #229

thai-lint did not ship a `.pre-commit-hooks.yaml` manifest, so it could not be consumed the standard way (`repo:` + pinned `rev:`). Consumers had to copy-paste `repo: local` / `language: system` hooks that shell out to a pre-installed CLI via a specific runner. This PR adds a first-class manifest so any repo can pin and consume thai-lint's linters under both [pre-commit](https://pre-commit.com/) and [prek](https://github.com/j178/prek).

## Changes

- **`.pre-commit-hooks.yaml`** — declares all 19 stable linters as `language: python` hooks (`thailint-*`). The framework builds/installs thailint from the pinned revision, so consumers need no pre-installed CLI and no runner assumption. Each hook is scoped to the file types its linter supports via `types_or` (e.g. Rust-only linters to `[rust]`, `version-freshness` to `[dockerfile, terraform, yaml, toml]`).
- **`tests/unit/test_pre_commit_hooks_manifest.py`** — regression test validating manifest structure (valid YAML list, unique `thailint-` ids, `language: python`, valid `types_or`) and cross-checking every hook `entry` subcommand against the live CLI command registry, so a renamed/removed command fails CI instead of breaking downstream consumers.
- **`docs/pre-commit-hooks.md`** — documents `repo:` consumption as the recommended path, with the existing local-hook patterns retained as an alternative.
- **`CHANGELOG.md`** — `[Unreleased]` entry under Added.

## Test Plan

- [x] New regression test added (`tests/unit/test_pre_commit_hooks_manifest.py`) — 10 passing
- [x] `pre-commit validate-manifest .pre-commit-hooks.yaml` exits 0
- [x] `just lint-full` exits 0 (Pylint 10.00/10, Xenon A-grade)
- [x] `just test` — full suite passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)